### PR TITLE
✨ feat: 세미나 5주차 실습 과제 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ dependencies {
 
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -23,27 +23,12 @@ public class CommentController {
     private final CommentQueryService commentQueryService;
 
     @Operation(summary = "댓글 목록 조회")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "OK",
-//                    content = @Content(mediaType = "application/json",
-//                            schema = @Schema(implementation = CommentResDTO.CommentListResDTO.class))),
-//            @ApiResponse(responseCode = "404", description = "Not Found",
-//                    content = @Content(mediaType = "application/json"))
-//    })
     @GetMapping("reviews/{reviewId}/comments")
     public ResponseEntity<CommentResDTO.CommentListResDTO> getComment(@PathVariable Long reviewId) {
         return ResponseEntity.ok(commentQueryService.getCommentList(reviewId));
     }
 
     @Operation(summary = "댓글 작성")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "201", description = "Created",
-//                    content = @Content(mediaType = "application/json")),
-//            @ApiResponse(responseCode = "400", description = "Bad Request",
-//                    content = @Content(mediaType = "application/json")),
-//            @ApiResponse(responseCode = "404", description = "Not Found",
-//                    content = @Content(mediaType = "application/json"))
-//    })
     @PostMapping("reviews/{reviewId}/comments")
     public ResponseEntity<CommentResDTO.CommentCreateResDTO> createComment(
             @PathVariable Long reviewId, @RequestBody CommentReqDTO.CommentCreateReqDTO commentCreateReqDTO) {
@@ -53,26 +38,12 @@ public class CommentController {
     }
 
     @Operation(summary = "댓글 수정")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "OK",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "Bad Request",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "404", description = "Not Found",
-                    content = @Content(mediaType = "application/json"))
-    })
     @PatchMapping("comment/{commentId}")
     public ResponseEntity<?> updateComment(@PathVariable Long commentId, @RequestBody CommentReqDTO.CommentUpdateReqDTO commentUpdateReqDTO) {
         return null;
     }
 
     @Operation(summary = "댓글 삭제")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "No Content",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "404", description = "Not Found",
-                    content = @Content(mediaType = "application/json"))
-    })
     @DeleteMapping("comment/{commentId}")
     public ResponseEntity<?> deleteComment(@PathVariable Long commentId) {
         return null;

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -25,8 +25,8 @@ public class CommentController {
 
     @Operation(summary = "댓글 목록 조회")
     @GetMapping("reviews/{reviewId}/comments")
-    public ResponseEntity<CommentResDTO.CommentListResDTO> getComment(@PathVariable Long reviewId) {
-        return ResponseEntity.ok(commentQueryService.getCommentList(reviewId));
+    public CustomResponse<CommentResDTO.CommentListResDTO> getComment(@PathVariable Long reviewId) {
+        return CustomResponse.onSuccess(commentQueryService.getCommentList(reviewId));
     }
 
     @Operation(summary = "댓글 작성")

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -7,6 +7,7 @@ import com.project.likelion13thbe.domain.comment.service.query.CommentQueryServi
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -28,7 +29,8 @@ public class CommentController {
     @Operation(summary = "댓글 작성")
     @PostMapping("reviews/{reviewId}/comments")
     public CustomResponse<CommentResDTO.CommentCreateResDTO> createComment(
-            @PathVariable Long reviewId, @RequestBody CommentReqDTO.CommentCreateReqDTO commentCreateReqDTO) {
+            @PathVariable Long reviewId,
+            @RequestBody @Valid CommentReqDTO.CommentCreateReqDTO commentCreateReqDTO) {
         return CustomResponse.onSuccess(HttpStatus.CREATED, commentCommandService.createComment(commentCreateReqDTO, reviewId));
     }
 

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -38,8 +38,13 @@ public class CommentController {
 
     @Operation(summary = "댓글 수정")
     @PatchMapping("comment/{commentId}")
-    public ResponseEntity<?> updateComment(@PathVariable Long commentId, @RequestBody CommentReqDTO.CommentUpdateReqDTO commentUpdateReqDTO) {
-        return null;
+    public CustomResponse<String> updateComment(
+            @PathVariable Long commentId,
+            @RequestBody CommentReqDTO.CommentUpdateReqDTO commentUpdateReqDTO) {
+
+        commentCommandService.updateComment(commentUpdateReqDTO, commentId);
+
+        return CustomResponse.onSuccess("댓글 수정 완료");
     }
 
     @Operation(summary = "댓글 삭제")

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -4,6 +4,7 @@ import com.project.likelion13thbe.domain.comment.dto.request.CommentReqDTO;
 import com.project.likelion13thbe.domain.comment.dto.response.CommentResDTO;
 import com.project.likelion13thbe.domain.comment.service.command.CommentCommandService;
 import com.project.likelion13thbe.domain.comment.service.query.CommentQueryService;
+import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -45,7 +46,10 @@ public class CommentController {
 
     @Operation(summary = "댓글 삭제")
     @DeleteMapping("comment/{commentId}")
-    public ResponseEntity<?> deleteComment(@PathVariable Long commentId) {
-        return null;
+    public CustomResponse<String> deleteComment(@PathVariable Long commentId) {
+
+        commentCommandService.deleteComment(commentId);
+
+        return CustomResponse.onSuccess(HttpStatus.NO_CONTENT, "댓글 삭제 완료");
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -53,4 +53,14 @@ public class CommentController {
 
         return CustomResponse.onSuccess(HttpStatus.NO_CONTENT, "댓글 삭제 완료");
     }
+
+    @Operation(summary = "댓글 목록 조회 (커서 방식)")
+    @GetMapping("/reviews/{reviewId}/comments-cursor/")
+    public CustomResponse<CommentResDTO.CommentCursorResDTO> getCommentCursor(
+            @PathVariable Long reviewId,
+            @RequestParam Long cursor,
+            @RequestParam Integer size
+    ) {
+        return CustomResponse.onSuccess(commentQueryService.getCommentCursor(reviewId, cursor, size));
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -6,13 +6,9 @@ import com.project.likelion13thbe.domain.comment.service.command.CommentCommandS
 import com.project.likelion13thbe.domain.comment.service.query.CommentQueryService;
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -38,7 +38,7 @@ public class CommentController {
     @PatchMapping("comment/{commentId}")
     public CustomResponse<String> updateComment(
             @PathVariable Long commentId,
-            @RequestBody CommentReqDTO.CommentUpdateReqDTO commentUpdateReqDTO) {
+            @RequestBody @Valid CommentReqDTO.CommentUpdateReqDTO commentUpdateReqDTO) {
 
         commentCommandService.updateComment(commentUpdateReqDTO, commentId);
 

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -35,7 +35,7 @@ public class CommentController {
     }
 
     @Operation(summary = "댓글 수정")
-    @PatchMapping("comment/{commentId}")
+    @PatchMapping("comments/{commentId}")
     public CustomResponse<String> updateComment(
             @PathVariable Long commentId,
             @RequestBody @Valid CommentReqDTO.CommentUpdateReqDTO commentUpdateReqDTO) {
@@ -46,7 +46,7 @@ public class CommentController {
     }
 
     @Operation(summary = "댓글 삭제")
-    @DeleteMapping("comment/{commentId}")
+    @DeleteMapping("comments/{commentId}")
     public CustomResponse<String> deleteComment(@PathVariable Long commentId) {
 
         commentCommandService.deleteComment(commentId);

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -31,11 +31,9 @@ public class CommentController {
 
     @Operation(summary = "댓글 작성")
     @PostMapping("reviews/{reviewId}/comments")
-    public ResponseEntity<CommentResDTO.CommentCreateResDTO> createComment(
+    public CustomResponse<CommentResDTO.CommentCreateResDTO> createComment(
             @PathVariable Long reviewId, @RequestBody CommentReqDTO.CommentCreateReqDTO commentCreateReqDTO) {
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(commentCommandService.createComment(commentCreateReqDTO, reviewId));
+        return CustomResponse.onSuccess(HttpStatus.CREATED, commentCommandService.createComment(commentCreateReqDTO, reviewId));
     }
 
     @Operation(summary = "댓글 수정")

--- a/src/main/java/com/project/likelion13thbe/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/converter/CommentConverter.java
@@ -7,6 +7,7 @@ import com.project.likelion13thbe.domain.member.entity.Member;
 import com.project.likelion13thbe.domain.review.entity.Review;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
@@ -44,6 +45,24 @@ public class CommentConverter {
     public static CommentResDTO.CommentListResDTO toCommentListResDTO(List<CommentResDTO.CommentDetailResDTO> commentList) {
         return CommentResDTO.CommentListResDTO.builder()
                 .commentList(commentList)
+                .build();
+    }
+
+    public static CommentResDTO.CommentCursorResDTO toCommentCursorResDTO(Slice<Comment> comments) {
+        List<CommentResDTO.CommentDetailResDTO> commentList = comments.stream()
+                .map(CommentConverter::toCommentDetailResDTO)
+                .toList();
+
+        // 다음 cursor 지정
+        Long nextCursor = null;
+        if (!comments.isEmpty() && comments.hasNext()) {
+            nextCursor = comments.getContent().get(comments.getNumberOfElements() - 1).getCommentId();
+        }
+
+        return CommentResDTO.CommentCursorResDTO.builder()
+                .comments(commentList)
+                .hasNext(comments.hasNext())
+                .nextCursor(nextCursor)
                 .build();
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/dto/request/CommentReqDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/dto/request/CommentReqDTO.java
@@ -1,7 +1,5 @@
 package com.project.likelion13thbe.domain.comment.dto.request;
 
-import lombok.Builder;
-
 public class CommentReqDTO {
 
     public record CommentCreateReqDTO(

--- a/src/main/java/com/project/likelion13thbe/domain/comment/dto/request/CommentReqDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/dto/request/CommentReqDTO.java
@@ -1,9 +1,12 @@
 package com.project.likelion13thbe.domain.comment.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public class CommentReqDTO {
 
     public record CommentCreateReqDTO(
             Long memberId,
+            @NotBlank(message = "댓글 내용은 필수 입력값입니다.")
             String content
     ) {
     }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/dto/request/CommentReqDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/dto/request/CommentReqDTO.java
@@ -12,6 +12,7 @@ public class CommentReqDTO {
     }
 
     public record CommentUpdateReqDTO(
+            @NotBlank(message = "댓글 내용은 필수 입력값입니다.")
             String content
     ) {
     }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/dto/response/CommentResDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/dto/response/CommentResDTO.java
@@ -31,4 +31,12 @@ public class CommentResDTO {
             LocalDateTime createdAt
     ) {
     }
+
+    @Builder
+    public record CommentCursorResDTO(
+            List<CommentResDTO.CommentDetailResDTO> comments,
+            Long nextCursor,
+            Boolean hasNext
+    ) {
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/entity/Comment.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/entity/Comment.java
@@ -6,6 +6,8 @@ import com.project.likelion13thbe.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -27,4 +29,13 @@ public class Comment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
     private Review review;
+
+    // soft delete를 위한 필드 추가
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    // soft delete 메서드
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/entity/Comment.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/entity/Comment.java
@@ -34,6 +34,11 @@ public class Comment extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    // comment update 메서드
+    public void updateComment(String content) {
+        this.content = content;
+    }
+
     // soft delete 메서드
     public void delete() {
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/project/likelion13thbe/domain/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/exception/CommentErrorCode.java
@@ -1,0 +1,17 @@
+package com.project.likelion13thbe.domain.comment.exception;
+
+import com.project.likelion13thbe.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CommentErrorCode implements BaseErrorCode {
+
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404_1", "댓글을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/likelion13thbe/domain/comment/exception/CommentException.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/exception/CommentException.java
@@ -1,0 +1,9 @@
+package com.project.likelion13thbe.domain.comment.exception;
+
+import com.project.likelion13thbe.global.apiPayload.exception.CustomException;
+
+public class CommentException extends CustomException {
+    public CommentException(CommentErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,8 @@
 package com.project.likelion13thbe.domain.comment.repository;
 
 import com.project.likelion13thbe.domain.comment.entity.Comment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -27,4 +29,12 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "FROM Comment c " +
             "WHERE c.deletedAt IS NOT NULL AND c.deletedAt <= :oneWeekAgo")
     List<Comment> findDeletedCommentsBefore(@Param("oneWeekAgo") LocalDateTime oneWeekAgo);
+
+    @Query("SELECT c " +
+            "FROM Comment c " +
+            "WHERE c.review.reviewId = :reviewId AND c.commentId < :cursor AND c.deletedAt IS NULL " +
+            "ORDER BY c.commentId DESC")
+    Slice<Comment> findAllCommentByReivewIdLessThanOrderByCommentIdDesc(
+            @Param("reviewId") Long reviewId, @Param("cursor") Long cursor, Pageable pageable);
+
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/repository/CommentRepository.java
@@ -11,8 +11,10 @@ import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    @Query("SELECT c FROM Comment c WHERE c.review.reviewId = :reviewId")
-    List<Comment> findCommentByReviewId(Long reviewId);
+    @Query("SELECT c " +
+            "FROM Comment c " +
+            "WHERE c.review.reviewId = :reviewId AND c.deletedAt IS NULL")
+    List<Comment> findCommentByReviewIdAndNotDeleted(Long reviewId);
 
     @Query("SELECT c " +
             "FROM Comment c " +

--- a/src/main/java/com/project/likelion13thbe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,6 @@
 package com.project.likelion13thbe.domain.comment.repository;
 
 import com.project.likelion13thbe.domain.comment.entity.Comment;
-import com.project.likelion13thbe.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/project/likelion13thbe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/repository/CommentRepository.java
@@ -1,11 +1,13 @@
 package com.project.likelion13thbe.domain.comment.repository;
 
 import com.project.likelion13thbe.domain.comment.entity.Comment;
+import com.project.likelion13thbe.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,4 +22,10 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "FROM Comment c " +
             "WHERE c.commentId = :commentId AND c.deletedAt IS NULL")
     Optional<Comment> findByCommentIdAndNotDeleted(@Param("commentId") Long commentId);
+
+    // 소프트 딜리트된 지 7일 지난 댓글 조회
+    @Query("SELECT c " +
+            "FROM Comment c " +
+            "WHERE c.deletedAt IS NOT NULL AND c.deletedAt <= :oneWeekAgo")
+    List<Comment> findDeletedCommentsBefore(@Param("oneWeekAgo") LocalDateTime oneWeekAgo);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/repository/CommentRepository.java
@@ -3,12 +3,19 @@ package com.project.likelion13thbe.domain.comment.repository;
 import com.project.likelion13thbe.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c WHERE c.review.reviewId = :reviewId")
     List<Comment> findCommentByReviewId(Long reviewId);
+
+    @Query("SELECT c " +
+            "FROM Comment c " +
+            "WHERE c.commentId = :commentId AND c.deletedAt IS NULL")
+    Optional<Comment> findByCommentIdAndNotDeleted(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
@@ -6,5 +6,7 @@ import com.project.likelion13thbe.domain.comment.dto.response.CommentResDTO;
 public interface CommentCommandService {
     public CommentResDTO.CommentCreateResDTO createComment(CommentReqDTO.CommentCreateReqDTO commentCreateReqDTO, Long reviewId);
 
+    public void updateComment(CommentReqDTO.CommentUpdateReqDTO commentUpdateReqDTO, Long commentId);
+
     public void deleteComment(Long commentId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
@@ -5,4 +5,6 @@ import com.project.likelion13thbe.domain.comment.dto.response.CommentResDTO;
 
 public interface CommentCommandService {
     public CommentResDTO.CommentCreateResDTO createComment(CommentReqDTO.CommentCreateReqDTO commentCreateReqDTO, Long reviewId);
+
+    public void deleteComment(Long commentId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
@@ -4,9 +4,9 @@ import com.project.likelion13thbe.domain.comment.dto.request.CommentReqDTO;
 import com.project.likelion13thbe.domain.comment.dto.response.CommentResDTO;
 
 public interface CommentCommandService {
-    public CommentResDTO.CommentCreateResDTO createComment(CommentReqDTO.CommentCreateReqDTO commentCreateReqDTO, Long reviewId);
+    CommentResDTO.CommentCreateResDTO createComment(CommentReqDTO.CommentCreateReqDTO commentCreateReqDTO, Long reviewId);
 
-    public void updateComment(CommentReqDTO.CommentUpdateReqDTO commentUpdateReqDTO, Long commentId);
+    void updateComment(CommentReqDTO.CommentUpdateReqDTO commentUpdateReqDTO, Long commentId);
 
-    public void deleteComment(Long commentId);
+    void deleteComment(Long commentId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
@@ -16,9 +16,15 @@ import com.project.likelion13thbe.domain.review.exception.ReviewErrorCode;
 import com.project.likelion13thbe.domain.review.exception.ReviewException;
 import com.project.likelion13thbe.domain.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -56,5 +62,32 @@ public class CommentCommandServiceImpl implements CommentCommandService {
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
 
         comment.delete();
+    }
+
+    @Scheduled(cron = "0 0 6 * * *")
+    @Transactional
+    public void cleanupDeletedComment() {
+        log.info("삭제된 댓글을 제거하는 스케쥴 시작");
+
+        // 일주일 전 날짜 계산
+        LocalDateTime oneWeekAgo = LocalDateTime.now().minusWeeks(1);
+
+        // 일주일 전 이전에 소프트 딜리트된 리뷰 조회
+        List<Comment> commentsToDelete = commentRepository.findDeletedCommentsBefore(oneWeekAgo);
+
+        if (commentsToDelete.isEmpty()) {
+            log.info("제거할 댓글이 없습니다.");
+            return;
+        }
+        for (Comment comment : commentsToDelete) {
+            try {
+                log.info("리뷰 삭제 시도: id={}", comment.getCommentId());
+                commentRepository.delete(comment);
+                log.info("리뷰 삭제 성공: id={}", comment.getCommentId());
+            } catch (Exception e) {
+                log.error("리뷰 삭제 실패: id={}, 이유={}", comment.getDeletedAt(), e.getMessage());
+            }
+        }
+        log.info("삭제가 완료되었습니다.\n");
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
@@ -8,8 +8,12 @@ import com.project.likelion13thbe.domain.comment.exception.CommentErrorCode;
 import com.project.likelion13thbe.domain.comment.exception.CommentException;
 import com.project.likelion13thbe.domain.comment.repository.CommentRepository;
 import com.project.likelion13thbe.domain.member.entity.Member;
+import com.project.likelion13thbe.domain.member.exception.MemberErrorCode;
+import com.project.likelion13thbe.domain.member.exception.MemberException;
 import com.project.likelion13thbe.domain.member.repository.MemberRepository;
 import com.project.likelion13thbe.domain.review.entity.Review;
+import com.project.likelion13thbe.domain.review.exception.ReviewErrorCode;
+import com.project.likelion13thbe.domain.review.exception.ReviewException;
 import com.project.likelion13thbe.domain.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,10 +30,10 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 
     @Override
     public CommentResDTO.CommentCreateResDTO createComment(CommentReqDTO.CommentCreateReqDTO commentCreateReqDTO, Long reviewId) {
-        Member member = memberRepository.findById(commentCreateReqDTO.memberId())
-                .orElseThrow(() -> new RuntimeException("Member가 존재하지 않음"));
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new RuntimeException("review가 존재하지 않음"));
+        Member member = memberRepository.findByMemberIdAndNotDeleted(commentCreateReqDTO.memberId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Review review = reviewRepository.findByReviewIdAndNotDeleted(reviewId)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
         Comment comment = CommentConverter.toComment(commentCreateReqDTO, member, review);
 

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
@@ -4,6 +4,8 @@ import com.project.likelion13thbe.domain.comment.converter.CommentConverter;
 import com.project.likelion13thbe.domain.comment.dto.request.CommentReqDTO;
 import com.project.likelion13thbe.domain.comment.dto.response.CommentResDTO;
 import com.project.likelion13thbe.domain.comment.entity.Comment;
+import com.project.likelion13thbe.domain.comment.exception.CommentErrorCode;
+import com.project.likelion13thbe.domain.comment.exception.CommentException;
 import com.project.likelion13thbe.domain.comment.repository.CommentRepository;
 import com.project.likelion13thbe.domain.member.entity.Member;
 import com.project.likelion13thbe.domain.member.repository.MemberRepository;
@@ -34,5 +36,13 @@ public class CommentCommandServiceImpl implements CommentCommandService {
         commentRepository.save(comment);
 
         return CommentConverter.toCommentCreateResDTO(comment);
+    }
+
+    @Override
+    public void deleteComment(Long commentId) {
+        Comment comment = commentRepository.findByCommentIdAndNotDeleted(commentId)
+                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        comment.delete();
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
@@ -43,6 +43,14 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     }
 
     @Override
+    public void updateComment(CommentReqDTO.CommentUpdateReqDTO commentUpdateReqDTO, Long commentId) {
+        Comment comment = commentRepository.findByCommentIdAndNotDeleted(commentId)
+                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        comment.updateComment(commentUpdateReqDTO.content());
+    }
+
+    @Override
     public void deleteComment(Long commentId) {
         Comment comment = commentRepository.findByCommentIdAndNotDeleted(commentId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/query/CommentQueryService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/query/CommentQueryService.java
@@ -3,7 +3,7 @@ package com.project.likelion13thbe.domain.comment.service.query;
 import com.project.likelion13thbe.domain.comment.dto.response.CommentResDTO;
 
 public interface CommentQueryService {
-    public CommentResDTO.CommentListResDTO getCommentList(Long reviewId);
+    CommentResDTO.CommentListResDTO getCommentList(Long reviewId);
 
-    public CommentResDTO.CommentCursorResDTO getCommentCursor(Long reviewId, Long cursor, Integer size);
+    CommentResDTO.CommentCursorResDTO getCommentCursor(Long reviewId, Long cursor, Integer size);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/query/CommentQueryService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/query/CommentQueryService.java
@@ -4,4 +4,6 @@ import com.project.likelion13thbe.domain.comment.dto.response.CommentResDTO;
 
 public interface CommentQueryService {
     public CommentResDTO.CommentListResDTO getCommentList(Long reviewId);
+
+    public CommentResDTO.CommentCursorResDTO getCommentCursor(Long reviewId, Long cursor, Integer size);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/query/CommentQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/query/CommentQueryServiceImpl.java
@@ -3,6 +3,8 @@ package com.project.likelion13thbe.domain.comment.service.query;
 import com.project.likelion13thbe.domain.comment.converter.CommentConverter;
 import com.project.likelion13thbe.domain.comment.dto.response.CommentResDTO;
 import com.project.likelion13thbe.domain.comment.entity.Comment;
+import com.project.likelion13thbe.domain.comment.exception.CommentErrorCode;
+import com.project.likelion13thbe.domain.comment.exception.CommentException;
 import com.project.likelion13thbe.domain.comment.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,9 +20,9 @@ public class CommentQueryServiceImpl implements CommentQueryService {
 
     @Override
     public CommentResDTO.CommentListResDTO getCommentList(Long reviewId) {
-        List<Comment> commentList = commentRepository.findCommentByReviewId(reviewId);
+        List<Comment> commentList = commentRepository.findCommentByReviewIdAndNotDeleted(reviewId);
         if (commentList.isEmpty()) {
-            throw new RuntimeException("Comment가 존재하지 않음");
+            throw new CommentException(CommentErrorCode.COMMENT_NOT_FOUND);
         }
         List<CommentResDTO.CommentDetailResDTO> filteredCommentDetailResDTOList =
                 commentList.stream()

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/query/CommentQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/query/CommentQueryServiceImpl.java
@@ -7,6 +7,9 @@ import com.project.likelion13thbe.domain.comment.exception.CommentErrorCode;
 import com.project.likelion13thbe.domain.comment.exception.CommentException;
 import com.project.likelion13thbe.domain.comment.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,5 +33,19 @@ public class CommentQueryServiceImpl implements CommentQueryService {
                         .toList();
 
         return CommentConverter.toCommentListResDTO(filteredCommentDetailResDTOList);
+    }
+
+    @Override
+    public CommentResDTO.CommentCursorResDTO getCommentCursor(Long reviewId, Long cursor, Integer size) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        // cursor가 0일 경우(첫페이지) cursor 최대값
+        if (cursor == 0) {
+            cursor = Long.MAX_VALUE;
+        }
+
+        Slice<Comment> comments = commentRepository.findAllCommentByReivewIdLessThanOrderByCommentIdDesc(reviewId, cursor, pageable);
+
+        return CommentConverter.toCommentCursorResDTO(comments);
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
@@ -6,10 +6,6 @@ import com.project.likelion13thbe.domain.member.service.command.MemberCommandSer
 import com.project.likelion13thbe.domain.member.service.query.MemberQueryService;
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController {
     @Operation(summary = "createMember")
     @PostMapping
     public CustomResponse<MemberResDTO.MemberCreateResDTO> createMember(
-            @RequestBody MemberReqDTO.MemberCreateReqDTO memberCreateReqDTO) {
+            @RequestBody @Valid MemberReqDTO.MemberCreateReqDTO memberCreateReqDTO) {
         return CustomResponse.onSuccess(memberCommandService.createMember(memberCreateReqDTO));
     }
 
@@ -132,5 +132,4 @@ public class MemberController {
         // 능력 부족 이슈로 카카오는 뭔가 이해가 어렵네요
         return null;
     }
-
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
@@ -73,63 +73,63 @@ public class MemberController {
     ) {
         return ResponseEntity.ok(memberQueryService.getMemberCursor(cursor, size));
     }
-
-    @Operation(summary = "비밀번호 수정")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "OK",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "Bad Request",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "401", description = "Unauthorized",
-                    content = @Content(mediaType = "application/json"))
-    })
-    @PostMapping("password-reset")
-    public ResponseEntity<?> resetPassword(@RequestBody MemberReqDTO.ResetPasswordReqDTO resetPasswordReqDTO) {
-        return null;
-    }
-
-    @Operation(summary = "회원 가입")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "OK",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "Bad Request",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "409", description = "Conflict",
-                    content = @Content(mediaType = "application/json"))
-    })
-    @PostMapping("sign-up")
-    public ResponseEntity<?> signUp(@RequestBody MemberReqDTO.SignUpResDTO signUpResDTO) {
-        return null;
-    }
-
-    @Operation(summary = "로그인")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "OK",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = MemberResDTO.LoginJwtTokenResDTO.class))),
-            @ApiResponse(responseCode = "401", description = "Unauthorized",
-                    content = @Content(mediaType = "application/json"))
-    })
-    @PostMapping("login")
-    public ResponseEntity<MemberResDTO.LoginJwtTokenResDTO> login(@RequestBody MemberReqDTO.LoginResDTO LoginResDTO) {
-        return null;
-    }
-
-    @Operation(summary = "카카오 로그인")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "OK",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = MemberResDTO.LoginJwtTokenResDTO.class))),
-            @ApiResponse(responseCode = "401", description = "Unauthorized",
-                    content = @Content(mediaType = "application/json"))
-    })
-    @PostMapping("login/kakao")
-    public ResponseEntity<MemberResDTO.LoginJwtTokenResDTO> kakaoLogin(@RequestBody MemberReqDTO.KakaoLoginResDTO KakaoLoginResDTO) {
-        // 프론트가 카카오에게 받은 인가코드를 Req에 넣어서 백엔드에 전달하면
-        // 백엔드가 카카오에서 토큰을 받아오고
-        // 자체적인 서비스 전용 jwt를 만들어서 Res로 보내주는 방식이긴 합니다만, 아직까지도 아리송합니다
-        // 그리고 토큰을 ResBody에 보내면 xss같은 탈취 보안 이슈가 있어 ResHead로 보내야 한다고는 합니다만...
-        // 능력 부족 이슈로 카카오는 뭔가 이해가 어렵네요
-        return null;
-    }
+//
+//    @Operation(summary = "비밀번호 수정")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "OK",
+//                    content = @Content(mediaType = "application/json")),
+//            @ApiResponse(responseCode = "400", description = "Bad Request",
+//                    content = @Content(mediaType = "application/json")),
+//            @ApiResponse(responseCode = "401", description = "Unauthorized",
+//                    content = @Content(mediaType = "application/json"))
+//    })
+//    @PostMapping("password-reset")
+//    public ResponseEntity<?> resetPassword(@RequestBody MemberReqDTO.ResetPasswordReqDTO resetPasswordReqDTO) {
+//        return null;
+//    }
+//
+//    @Operation(summary = "회원 가입")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "OK",
+//                    content = @Content(mediaType = "application/json")),
+//            @ApiResponse(responseCode = "400", description = "Bad Request",
+//                    content = @Content(mediaType = "application/json")),
+//            @ApiResponse(responseCode = "409", description = "Conflict",
+//                    content = @Content(mediaType = "application/json"))
+//    })
+//    @PostMapping("sign-up")
+//    public ResponseEntity<?> signUp(@RequestBody MemberReqDTO.SignUpResDTO signUpResDTO) {
+//        return null;
+//    }
+//
+//    @Operation(summary = "로그인")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "OK",
+//                    content = @Content(mediaType = "application/json",
+//                            schema = @Schema(implementation = MemberResDTO.LoginJwtTokenResDTO.class))),
+//            @ApiResponse(responseCode = "401", description = "Unauthorized",
+//                    content = @Content(mediaType = "application/json"))
+//    })
+//    @PostMapping("login")
+//    public ResponseEntity<MemberResDTO.LoginJwtTokenResDTO> login(@RequestBody MemberReqDTO.LoginResDTO LoginResDTO) {
+//        return null;
+//    }
+//
+//    @Operation(summary = "카카오 로그인")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "OK",
+//                    content = @Content(mediaType = "application/json",
+//                            schema = @Schema(implementation = MemberResDTO.LoginJwtTokenResDTO.class))),
+//            @ApiResponse(responseCode = "401", description = "Unauthorized",
+//                    content = @Content(mediaType = "application/json"))
+//    })
+//    @PostMapping("login/kakao")
+//    public ResponseEntity<MemberResDTO.LoginJwtTokenResDTO> kakaoLogin(@RequestBody MemberReqDTO.KakaoLoginResDTO KakaoLoginResDTO) {
+//        // 프론트가 카카오에게 받은 인가코드를 Req에 넣어서 백엔드에 전달하면
+//        // 백엔드가 카카오에서 토큰을 받아오고
+//        // 자체적인 서비스 전용 jwt를 만들어서 Res로 보내주는 방식이긴 합니다만, 아직까지도 아리송합니다
+//        // 그리고 토큰을 ResBody에 보내면 xss같은 탈취 보안 이슈가 있어 ResHead로 보내야 한다고는 합니다만...
+//        // 능력 부족 이슈로 카카오는 뭔가 이해가 어렵네요
+//        return null;
+//    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -40,7 +41,7 @@ public class MemberController {
     @PatchMapping("/{memberId}/password")
     public CustomResponse<String> resetPassword(
             @PathVariable("memberId") Long memberId,
-            @RequestBody MemberReqDTO.PasswordResetDTO passwordResetDTO
+            @RequestBody @Valid MemberReqDTO.PasswordResetDTO passwordResetDTO
     ) {
         memberCommandService.updatePassword(memberId, passwordResetDTO);
         return CustomResponse.onSuccess("비밀번호 변경 성공");

--- a/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
@@ -25,11 +25,9 @@ public class MemberController {
 
     @Operation(summary = "createMember")
     @PostMapping
-    public ResponseEntity<MemberResDTO.MemberCreateResDTO> createMember(
+    public CustomResponse<MemberResDTO.MemberCreateResDTO> createMember(
             @RequestBody MemberReqDTO.MemberCreateReqDTO memberCreateReqDTO) {
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(memberCommandService.createMember(memberCreateReqDTO));
+        return CustomResponse.onSuccess(memberCommandService.createMember(memberCreateReqDTO));
     }
 
     @Operation(summary = "getMember")

--- a/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
@@ -48,6 +48,15 @@ public class MemberController {
         return CustomResponse.onSuccess("비밀번호 변경 성공");
     }
 
+    // 회원 탈퇴 (JWT 인증 필요)
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 성공")
+    @DeleteMapping("/{memberId}")
+    public CustomResponse<String> deleteMember(@PathVariable("memberId") Long memberId) {
+        memberCommandService.deleteMember(memberId);
+        return CustomResponse.onSuccess("회원 탈퇴 성공");
+    }
+
+
     @Operation(summary = "getOffset")
     @GetMapping("/offset")
     public ResponseEntity<MemberResDTO.MemberOffsetResDTO> getMemberOffset(

--- a/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.project.likelion13thbe.domain.member.dto.request.MemberReqDTO;
 import com.project.likelion13thbe.domain.member.dto.response.MemberResDTO;
 import com.project.likelion13thbe.domain.member.service.command.MemberCommandService;
 import com.project.likelion13thbe.domain.member.service.query.MemberQueryService;
+import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,7 +12,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,6 +36,16 @@ public class MemberController {
     @GetMapping
     public ResponseEntity<MemberResDTO.MemberPreviewResDTO> getMember() {
         return ResponseEntity.ok(memberQueryService.getMember());
+    }
+
+    @Operation(summary = "비밀번호 수정")
+    @PatchMapping("/{memberId}/password")
+    public CustomResponse<String> resetPassword(
+            @PathVariable("memberId") Long memberId,
+            @RequestBody MemberReqDTO.PasswordResetDTO passwordResetDTO
+    ) {
+        memberCommandService.updatePassword(memberId, passwordResetDTO);
+        return CustomResponse.onSuccess("비밀번호 변경 성공");
     }
 
     @Operation(summary = "getOffset")

--- a/src/main/java/com/project/likelion13thbe/domain/member/dto/request/MemberReqDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/dto/request/MemberReqDTO.java
@@ -33,8 +33,11 @@ public class MemberReqDTO {
     }
 
     public record MemberCreateReqDTO(
+            @NotBlank(message = "이름은 필수 입력값입니다.")
             String nickname,
+            @NotBlank(message = "이메일은 필수 입력값입니다.")
             String email,
+            @NotBlank(message = "비밀번호는 필수 입력값입니다.")
             String password,
             SocialType socialType,
             String profileImage,

--- a/src/main/java/com/project/likelion13thbe/domain/member/dto/request/MemberReqDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/dto/request/MemberReqDTO.java
@@ -1,6 +1,9 @@
 package com.project.likelion13thbe.domain.member.dto.request;
 
 import com.project.likelion13thbe.domain.member.entity.SocialType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public class MemberReqDTO {
 
@@ -36,6 +39,14 @@ public class MemberReqDTO {
             SocialType socialType,
             String profileImage,
             Integer age
+    ) {
+    }
+
+    public record PasswordResetDTO (
+        @Schema(description = "새로운 비밀번호", example = "newpassword123")
+        @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
+        @Size(min = 8, max = 20, message = "비밀번호는 8~20자 사이여야 합니다.")
+        String password
     ) {
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/entity/Member.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/entity/Member.java
@@ -38,4 +38,9 @@ public class Member extends BaseEntity {
     private Team team;
 
 
+    // 비밀번호 변경 메서드
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
+
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/entity/Member.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/entity/Member.java
@@ -4,6 +4,8 @@ import com.project.likelion13thbe.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -37,10 +39,17 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "team_id")
     private Team team;
 
+    // soft delete를 위한 필드 추가
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     // 비밀번호 변경 메서드
     public void updatePassword(String newPassword) {
         this.password = newPassword;
     }
 
+    // soft delete 메서드
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/exception/MemberErrorCode.java
@@ -1,0 +1,18 @@
+package com.project.likelion13thbe.domain.member.exception;
+
+import com.project.likelion13thbe.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements BaseErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "회원을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}
+

--- a/src/main/java/com/project/likelion13thbe/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/exception/MemberErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "회원을 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "회원을 찾을 수 없습니다."),
+    MEMBER_EMAIL_DUPLICATE(HttpStatus.CONFLICT, "MEMBER409_1", "이미 사용 중인 이메일 입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/project/likelion13thbe/domain/member/exception/MemberException.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/exception/MemberException.java
@@ -1,0 +1,9 @@
+package com.project.likelion13thbe.domain.member.exception;
+
+import com.project.likelion13thbe.global.apiPayload.exception.CustomException;
+
+public class MemberException extends CustomException {
+  public MemberException(MemberErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/project/likelion13thbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/repository/MemberRepository.java
@@ -1,7 +1,6 @@
 package com.project.likelion13thbe.domain.member.repository;
 
 import com.project.likelion13thbe.domain.member.entity.Member;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;

--- a/src/main/java/com/project/likelion13thbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/repository/MemberRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -21,4 +23,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             "WHERE m.memberId = :memberId AND m.deletedAt IS NULL")
     Optional<Member> findByMemberIdAndNotDeleted(@Param("memberId") Long memberId);
 
+    // 소프트 딜리트된 지 30일 지난 멤버 조회
+    @Query("SELECT m " +
+            "FROM Member m " +
+            "WHERE m.deletedAt IS NOT NULL AND m.deletedAt <= :oneMonthAgo")
+    List<Member> findDeletedMembersBefore(@Param("oneMonthAgo") LocalDateTime oneMonthAgo);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/repository/MemberRepository.java
@@ -6,9 +6,20 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Page<Member> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     Slice<Member> findAllByMemberIdLessThanOrderByMemberIdDesc(Long memberId, Pageable pageable);
+
+    // 삭제되지 않은 회원 중 이메일로 조회
+    @Query("SELECT m " +
+            "FROM Member m " +
+            "WHERE m.memberId = :memberId AND m.deletedAt IS NULL")
+    Optional<Member> findByMemberIdAndNotDeleted(@Param("memberId") Long memberId);
+
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandService.java
@@ -4,9 +4,9 @@ import com.project.likelion13thbe.domain.member.dto.request.MemberReqDTO;
 import com.project.likelion13thbe.domain.member.dto.response.MemberResDTO;
 
 public interface MemberCommandService {
-    public MemberResDTO.MemberCreateResDTO createMember(MemberReqDTO.MemberCreateReqDTO memberCreateReqDTO);
+    MemberResDTO.MemberCreateResDTO createMember(MemberReqDTO.MemberCreateReqDTO memberCreateReqDTO);
 
-    public void updatePassword(Long memberId, MemberReqDTO.PasswordResetDTO passwordResetDTO);
+    void updatePassword(Long memberId, MemberReqDTO.PasswordResetDTO passwordResetDTO);
 
-    public void deleteMember(Long memberId);
+    void deleteMember(Long memberId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandService.java
@@ -5,4 +5,7 @@ import com.project.likelion13thbe.domain.member.dto.response.MemberResDTO;
 
 public interface MemberCommandService {
     public MemberResDTO.MemberCreateResDTO createMember(MemberReqDTO.MemberCreateReqDTO memberCreateReqDTO);
+
+    public void updatePassword(Long memberId, MemberReqDTO.PasswordResetDTO passwordResetDTO);
+
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandService.java
@@ -8,4 +8,5 @@ public interface MemberCommandService {
 
     public void updatePassword(Long memberId, MemberReqDTO.PasswordResetDTO passwordResetDTO);
 
+    public void deleteMember(Long memberId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -4,6 +4,8 @@ import com.project.likelion13thbe.domain.member.converter.MemberConverter;
 import com.project.likelion13thbe.domain.member.dto.request.MemberReqDTO;
 import com.project.likelion13thbe.domain.member.dto.response.MemberResDTO;
 import com.project.likelion13thbe.domain.member.entity.Member;
+import com.project.likelion13thbe.domain.member.exception.MemberErrorCode;
+import com.project.likelion13thbe.domain.member.exception.MemberException;
 import com.project.likelion13thbe.domain.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 @Transactional
 public class MemberCommandServiceImpl implements MemberCommandService {
     private final MemberRepository memberRepository;
+//    private final BCryptPasswordEncoder passwordEncoder;
 
     @Override
     public MemberResDTO.MemberCreateResDTO createMember(MemberReqDTO.MemberCreateReqDTO memberCreateReqDTO) {
@@ -26,4 +29,14 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         // 응답 DTO로 변환 후 return
         return MemberConverter.toMemberResponseDTO(member);
     }
+
+    @Override
+    public void updatePassword(Long memberId, MemberReqDTO.PasswordResetDTO passwordResetDTO) {
+        // 회원 정보 조회
+        Member member = memberRepository.findByMemberIdAndNotDeleted(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        member.updatePassword(passwordResetDTO.password());
+    }
+
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -39,4 +39,13 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         member.updatePassword(passwordResetDTO.password());
     }
 
+    @Override
+    public void deleteMember(Long memberId) {
+        // 회원 정보 조회
+        Member member = memberRepository.findByMemberIdAndNotDeleted(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // soft delete 처리
+        member.delete();
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -7,7 +7,6 @@ import com.project.likelion13thbe.domain.member.entity.Member;
 import com.project.likelion13thbe.domain.member.exception.MemberErrorCode;
 import com.project.likelion13thbe.domain.member.exception.MemberException;
 import com.project.likelion13thbe.domain.member.repository.MemberRepository;
-import com.project.likelion13thbe.global.apiPayload.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;

--- a/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -9,9 +9,15 @@ import com.project.likelion13thbe.domain.member.exception.MemberException;
 import com.project.likelion13thbe.domain.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -68,5 +74,33 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         // soft delete 처리
         member.delete();
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void cleanupDeletedMember() {
+        log.info("삭제된 멤버를 제거하는 스케쥴 시작");
+
+        // 한 달 전 날짜 계산
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+
+        // 한 달 전 이전에 소프트 딜리트된 회원 조회
+        List<Member> membersToDelete = memberRepository.findDeletedMembersBefore(oneMonthAgo);
+
+        if (membersToDelete.isEmpty()) {
+            log.info("제거할 멤버가 없습니다.");
+            return;
+        }
+        for (Member member : membersToDelete) {
+            try {
+                log.info("회원 삭제 시도: id={}, email={}", member.getMemberId(), member.getEmail());
+                memberRepository.delete(member);
+                log.info("회원 삭제 성공: id={}", member.getMemberId());
+            } catch (Exception e) {
+                // 연관 관계? CASCADE? 이슈
+                log.error("회원 삭제 실패: id={}, 이유={}", member.getMemberId(), e.getMessage());
+            }
+        }
+        log.info("삭제가 완료되었습니다.\n");
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -7,8 +7,10 @@ import com.project.likelion13thbe.domain.member.entity.Member;
 import com.project.likelion13thbe.domain.member.exception.MemberErrorCode;
 import com.project.likelion13thbe.domain.member.exception.MemberException;
 import com.project.likelion13thbe.domain.member.repository.MemberRepository;
+import com.project.likelion13thbe.global.apiPayload.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,7 +26,27 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         Member member = MemberConverter.toMember(memberCreateReqDTO);
 
         // Member 엔티티 DB에 저장
-        memberRepository.save(member);
+
+        // 이게 원래는 위에서 Member 객체를 생성할 때 검사를 해보려고 했는데,
+        // 찾아보니 객체 생성 단에서만 검사를 하면 정말 희박한 확률로 동시에 가입을 하려고 할 때,
+        // race condition 이슈가 발생할 수 있다고 해서 저장하는 그 순간에 try-catch 문을 작성했습니다.
+        // 최종 방어선은 DB가 지켜야 하니까요 (생각해보면 DB는 동시성 제어가 되니 무조건 승리자가 정해집니다)
+        // 그런데 실제로 회원가입을 했던 경험을 생각해보니 이메일 중복 검사를 하는데요
+        // A의 이메일 중복 검사 승인 O (DB에 실제로 저장되진 않음) -> A가 회원가입 전체 폼 작성이 오래 걸렸음 + 아직 작성 중
+        // -> B가 A와 동일한 이메일로 중복 검사 승인 (DB에 저장이 안된 값이니까 승인은 됨)
+        // -> B가 A보다 폼을 먼저 작성함 -> A는 이메일 중복 검사를 받았음에도 폼을 다 작성하니 unique 조건 에러 발생
+        // 회원 가입은 아무래도 시스템의 쾌적함을 위해서 병렬적으로 발생해야 한다고 생각하는데
+        // 그러면 회원가입 폼을 작성하기 전에 중복 확인을 받는 단계에서 이 이메일이 지금 가입 중에 있다라는
+        // 어느 정도 시간(20~30분)을 갖고 DB에 존재하게 임시 테이블을 작성하는 것도 방법일까요? 아니면 어떤 다른 방법이 있을까요?
+        // 마치 KTX 예약 장바구니에 담아두면 30분 뒤에 자동으로 자리가 풀리는 느낌입니다
+        // 지금 단계에서는 스웨거로 작성해서 병렬 요청이 불가하니 DB 단에서만 예외 처리를 했습니다
+
+        try {
+            memberRepository.save(member);
+        } catch (DataIntegrityViolationException e) {
+            throw new MemberException(MemberErrorCode.MEMBER_EMAIL_DUPLICATE);
+        }
+
 
         // 응답 DTO로 변환 후 return
         return MemberConverter.toMemberResponseDTO(member);

--- a/src/main/java/com/project/likelion13thbe/domain/member/service/query/MemberQueryService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/service/query/MemberQueryService.java
@@ -3,9 +3,9 @@ package com.project.likelion13thbe.domain.member.service.query;
 import com.project.likelion13thbe.domain.member.dto.response.MemberResDTO;
 
 public interface MemberQueryService {
-    public MemberResDTO.MemberPreviewResDTO getMember();
+    MemberResDTO.MemberPreviewResDTO getMember();
 
-    public MemberResDTO.MemberOffsetResDTO getMemberOffset(Integer offset, Integer size);
+    MemberResDTO.MemberOffsetResDTO getMemberOffset(Integer offset, Integer size);
 
-    public MemberResDTO.MemberCursorResDTO getMemberCursor(Long cursor, Integer size);
+    MemberResDTO.MemberCursorResDTO getMemberCursor(Long cursor, Integer size);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
@@ -46,4 +46,13 @@ public class ProductController {
         productCommandService.deleteProduct(productId);
         return CustomResponse.onSuccess(HttpStatus.NO_CONTENT, "상품 삭제 완료");
     }
+
+    @Operation(summary = "상품 목록 조회 (커서 방식)")
+    @GetMapping("/cursor")
+    public CustomResponse<ProductResDTO.ProductCursorResDTO> getProductCursor(
+            @RequestParam Long cursor,
+            @RequestParam Integer size
+    ) {
+        return CustomResponse.onSuccess(productQueryService.getProductCursor(cursor, size));
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
@@ -7,6 +7,7 @@ import com.project.likelion13thbe.domain.product.service.query.ProductQueryServi
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -34,7 +35,7 @@ public class ProductController {
     @Operation(summary = "상품 추가")
     @PostMapping
     public CustomResponse<ProductResDTO.ProductCreateResDTO> addProduct(
-            @RequestBody ProductReqDTO.ProductCreateReqDTO productCreateReqDTO) {
+            @RequestBody @Valid ProductReqDTO.ProductCreateReqDTO productCreateReqDTO) {
         return CustomResponse
                 .onSuccess(productCommandService.createProduct(productCreateReqDTO));
     }

--- a/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
@@ -55,11 +55,10 @@ public class ProductController {
 //                    content = @Content(mediaType = "application/json"))
 //    })
     @PostMapping
-    public ResponseEntity<ProductResDTO.ProductCreateResDTO> addProduct(
+    public CustomResponse<ProductResDTO.ProductCreateResDTO> addProduct(
             @RequestBody ProductReqDTO.ProductCreateReqDTO productCreateReqDTO) {
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(productCommandService.createProduct(productCreateReqDTO));
+        return CustomResponse
+                .onSuccess(productCommandService.createProduct(productCreateReqDTO));
     }
 
     @Operation(summary = "상품 삭제")

--- a/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
@@ -4,6 +4,7 @@ import com.project.likelion13thbe.domain.product.dto.request.ProductReqDTO;
 import com.project.likelion13thbe.domain.product.dto.response.ProductResDTO;
 import com.project.likelion13thbe.domain.product.service.command.ProductCommandService;
 import com.project.likelion13thbe.domain.product.service.query.ProductQueryService;
+import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -31,8 +32,8 @@ public class ProductController {
 //                    content = @Content(mediaType = "application/json"))
 //    })
     @GetMapping("/{productId}")
-    public ResponseEntity<ProductResDTO.ProductDetailResDTO> getProduct(@PathVariable Long productId) {
-        return ResponseEntity.ok(productQueryService.getProduct(productId));
+    public CustomResponse<ProductResDTO.ProductDetailResDTO> getProduct(@PathVariable Long productId) {
+        return CustomResponse.onSuccess(productQueryService.getProduct(productId));
     }
 
     @Operation(summary = "상품 목록 조회")
@@ -42,8 +43,8 @@ public class ProductController {
 //                            schema = @Schema(implementation = ProductResDTO.ProductListResDTO.class)))
 //    })
     @GetMapping
-    public ResponseEntity<ProductResDTO.ProductListResDTO> getProductList() {
-        return ResponseEntity.ok(productQueryService.getProductList());
+    public CustomResponse<ProductResDTO.ProductListResDTO> getProductList() {
+        return CustomResponse.onSuccess(productQueryService.getProductList());
     }
 
     @Operation(summary = "상품 추가")

--- a/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
@@ -24,36 +24,18 @@ public class ProductController {
     private final ProductQueryService productQueryService;
 
     @Operation(summary = "상품 상세 조회")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "OK",
-//                    content = @Content(mediaType = "application/json",
-//                            schema = @Schema(implementation = ProductResDTO.ProductDetailResDTO.class))),
-//            @ApiResponse(responseCode = "404", description = "Not Found",
-//                    content = @Content(mediaType = "application/json"))
-//    })
     @GetMapping("/{productId}")
     public CustomResponse<ProductResDTO.ProductDetailResDTO> getProduct(@PathVariable Long productId) {
         return CustomResponse.onSuccess(productQueryService.getProduct(productId));
     }
 
     @Operation(summary = "상품 목록 조회")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "OK",
-//                    content = @Content(mediaType = "application/json",
-//                            schema = @Schema(implementation = ProductResDTO.ProductListResDTO.class)))
-//    })
     @GetMapping
     public CustomResponse<ProductResDTO.ProductListResDTO> getProductList() {
         return CustomResponse.onSuccess(productQueryService.getProductList());
     }
 
     @Operation(summary = "상품 추가")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "201", description = "Created",
-//                    content = @Content(mediaType = "application/json")),
-//            @ApiResponse(responseCode = "400", description = "Bad Request",
-//                    content = @Content(mediaType = "application/json"))
-//    })
     @PostMapping
     public CustomResponse<ProductResDTO.ProductCreateResDTO> addProduct(
             @RequestBody ProductReqDTO.ProductCreateReqDTO productCreateReqDTO) {
@@ -62,12 +44,6 @@ public class ProductController {
     }
 
     @Operation(summary = "상품 삭제")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "No Content",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "404", description = "Not Found",
-                    content = @Content(mediaType = "application/json"))
-    })
     @DeleteMapping("{productId}")
     public ResponseEntity<?> deleteProduct(@PathVariable Long productId) {
         return null;

--- a/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
@@ -45,7 +45,8 @@ public class ProductController {
 
     @Operation(summary = "상품 삭제")
     @DeleteMapping("{productId}")
-    public ResponseEntity<?> deleteProduct(@PathVariable Long productId) {
-        return null;
+    public CustomResponse<String> deleteProduct(@PathVariable Long productId) {
+        productCommandService.deleteProduct(productId);
+        return CustomResponse.onSuccess(HttpStatus.NO_CONTENT, "상품 삭제 완료");
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/controller/ProductController.java
@@ -6,13 +6,9 @@ import com.project.likelion13thbe.domain.product.service.command.ProductCommandS
 import com.project.likelion13thbe.domain.product.service.query.ProductQueryService;
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/java/com/project/likelion13thbe/domain/product/converter/ProductConverter.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/converter/ProductConverter.java
@@ -1,11 +1,13 @@
 package com.project.likelion13thbe.domain.product.converter;
 
 import com.project.likelion13thbe.domain.member.entity.Member;
+import com.project.likelion13thbe.domain.product.dto.ProductDetailDTO;
 import com.project.likelion13thbe.domain.product.dto.request.ProductReqDTO;
 import com.project.likelion13thbe.domain.product.dto.response.ProductResDTO;
 import com.project.likelion13thbe.domain.product.entity.Product;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
@@ -46,6 +48,25 @@ public class ProductConverter {
     public static ProductResDTO.ProductListResDTO toProductListResDTO(List<ProductResDTO.ProductDetailResDTO> productList) {
         return ProductResDTO.ProductListResDTO.builder()
                 .productList(productList)
+                .build();
+    }
+
+    public static ProductResDTO.ProductCursorResDTO toProductCursorResDTO(Slice<ProductDetailDTO> productDetailDTOSlice) {
+        List<ProductResDTO.ProductDetailResDTO> productList = productDetailDTOSlice.stream()
+                .map(productDetailDTO -> toProductDetailResDTO(
+                        productDetailDTO.product(), productDetailDTO.ratingAvg(), productDetailDTO.reviewCount().intValue()))
+                .toList();
+
+        // 다음 cursor 지정
+        Long nextCursor = null;
+        if (!productDetailDTOSlice.isEmpty() && productDetailDTOSlice.hasNext()) {
+            nextCursor = productDetailDTOSlice.getContent().get(productDetailDTOSlice.getNumberOfElements() - 1).product().getProductId();
+        }
+
+        return ProductResDTO.ProductCursorResDTO.builder()
+                .products(productList)
+                .hasNext(productDetailDTOSlice.hasNext())
+                .nextCursor(nextCursor)
                 .build();
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/dto/request/ProductReqDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/dto/request/ProductReqDTO.java
@@ -1,16 +1,24 @@
 package com.project.likelion13thbe.domain.product.dto.request;
 
 import com.project.likelion13thbe.domain.product.entity.ProductType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public class ProductReqDTO {
 
     public record ProductCreateReqDTO(
             Long memberId,
+            @NotBlank(message = "상품 이름은 필수 입력값입니다.")
             String name,
+            @NotBlank(message = "상품 설명은 필수 입력값입니다.")
             String description,
+            @NotBlank(message = "상품 사진은 필수 입력값입니다.")
             String image,
+            @NotNull(message = "상품 가격은 필수 입력값입니다.")
             Double price,
+            @NotNull(message = "상품 타입은 필수 입력값입니다.")
             ProductType productType,
+            @NotNull(message = "상품 수량은 필수 입력값입니다.")
             Integer productQuantity
     ) {
     }

--- a/src/main/java/com/project/likelion13thbe/domain/product/dto/response/ProductResDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/dto/response/ProductResDTO.java
@@ -35,4 +35,11 @@ public class ProductResDTO {
     ) {
     }
 
+    @Builder
+    public record ProductCursorResDTO(
+            List<ProductDetailResDTO> products,
+            Long nextCursor,
+            Boolean hasNext
+    ) {
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/exception/ProductErrorCode.java
@@ -1,0 +1,16 @@
+package com.project.likelion13thbe.domain.product.exception;
+
+import com.project.likelion13thbe.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ProductErrorCode implements BaseErrorCode {
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT404_1", "상품을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/likelion13thbe/domain/product/exception/ProductException.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/exception/ProductException.java
@@ -1,0 +1,9 @@
+package com.project.likelion13thbe.domain.product.exception;
+
+import com.project.likelion13thbe.global.apiPayload.exception.CustomException;
+
+public class ProductException extends CustomException {
+    public ProductException(ProductErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/repository/ProductRepository.java
@@ -18,8 +18,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             ") " +
             "FROM Product p " +
             "LEFT JOIN Review r ON r.product.productId = p.productId " +
+            "WHERE r.deletedAt IS NULL " +
             "GROUP BY p")
-    List<ProductDetailDTO> findAllProductsWithReviewStats();
+    List<ProductDetailDTO> findAllProductsWithReviewStatsAndNotDeleted();
 
     @Query("SELECT new com.project.likelion13thbe.domain.product.dto.ProductDetailDTO(" +
             "p, " +
@@ -28,8 +29,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             ") " +
             "FROM Product p " +
             "LEFT JOIN Review r ON r.product.productId = p.productId " +
-            "WHERE p.productId = :productId " +
+            "WHERE p.productId = :productId AND r.deletedAt IS NULL " +
             "GROUP BY p")
-    Optional<ProductDetailDTO> findProductWithReviewStats(Long productId);
+    Optional<ProductDetailDTO> findProductWithReviewStatsAndNotDeleted(Long productId);
 
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/repository/ProductRepository.java
@@ -2,8 +2,11 @@ package com.project.likelion13thbe.domain.product.repository;
 
 import com.project.likelion13thbe.domain.product.dto.ProductDetailDTO;
 import com.project.likelion13thbe.domain.product.entity.Product;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -32,5 +35,19 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "WHERE p.productId = :productId AND r.deletedAt IS NULL " +
             "GROUP BY p")
     Optional<ProductDetailDTO> findProductWithReviewStatsAndNotDeleted(Long productId);
+
+    // cursor
+    @Query("SELECT new com.project.likelion13thbe.domain.product.dto.ProductDetailDTO(" +
+            "p, " +
+            "COALESCE(AVG(r.rating), 0.0), " +
+            "COUNT(r)" +
+            ") " +
+            "FROM Product p " +
+            "LEFT JOIN Review r ON r.product.productId = p.productId " +
+            "WHERE r.reviewId < :cursor AND r.deletedAt IS NULL " +
+            "GROUP BY p " +
+            "ORDER BY p.productId DESC")
+    Slice<ProductDetailDTO> findAllByProductIdLessThanOrderByProductIdDesc(@Param("cursor") Long cursor, Pageable pageable);
+
 
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/service/command/ProductCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/service/command/ProductCommandService.java
@@ -5,4 +5,6 @@ import com.project.likelion13thbe.domain.product.dto.response.ProductResDTO;
 
 public interface ProductCommandService {
     public ProductResDTO.ProductCreateResDTO createProduct(ProductReqDTO.ProductCreateReqDTO productCreateReqDTO);
+
+    public void deleteProduct(Long productId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/service/command/ProductCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/service/command/ProductCommandService.java
@@ -4,7 +4,7 @@ import com.project.likelion13thbe.domain.product.dto.request.ProductReqDTO;
 import com.project.likelion13thbe.domain.product.dto.response.ProductResDTO;
 
 public interface ProductCommandService {
-    public ProductResDTO.ProductCreateResDTO createProduct(ProductReqDTO.ProductCreateReqDTO productCreateReqDTO);
+    ProductResDTO.ProductCreateResDTO createProduct(ProductReqDTO.ProductCreateReqDTO productCreateReqDTO);
 
-    public void deleteProduct(Long productId);
+    void deleteProduct(Long productId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/service/command/ProductCommandServiceImpl.java
@@ -1,6 +1,8 @@
 package com.project.likelion13thbe.domain.product.service.command;
 
 import com.project.likelion13thbe.domain.member.entity.Member;
+import com.project.likelion13thbe.domain.member.exception.MemberErrorCode;
+import com.project.likelion13thbe.domain.member.exception.MemberException;
 import com.project.likelion13thbe.domain.member.repository.MemberRepository;
 import com.project.likelion13thbe.domain.product.converter.ProductConverter;
 import com.project.likelion13thbe.domain.product.dto.request.ProductReqDTO;
@@ -23,7 +25,8 @@ public class ProductCommandServiceImpl implements ProductCommandService {
         // 멤버를 토큰으로 구별하지만 아직 방법을 몰라서 일단 직접 주입
         // Req로 받은 멤버 아이디로 멤버 객체를 찾고
         Member member = memberRepository.findById(productCreateReqDTO.memberId())
-                .orElseThrow(() -> new RuntimeException("Member가 존재하지 않음"));
+                // 이 부분 일단 이렇게만 해놓겠습니다
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // ProductCreateReqDTO + Member => Entity
         Product product = ProductConverter.toProduct(productCreateReqDTO, member);

--- a/src/main/java/com/project/likelion13thbe/domain/product/service/command/ProductCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/service/command/ProductCommandServiceImpl.java
@@ -8,6 +8,8 @@ import com.project.likelion13thbe.domain.product.converter.ProductConverter;
 import com.project.likelion13thbe.domain.product.dto.request.ProductReqDTO;
 import com.project.likelion13thbe.domain.product.dto.response.ProductResDTO;
 import com.project.likelion13thbe.domain.product.entity.Product;
+import com.project.likelion13thbe.domain.product.exception.ProductErrorCode;
+import com.project.likelion13thbe.domain.product.exception.ProductException;
 import com.project.likelion13thbe.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,5 +36,13 @@ public class ProductCommandServiceImpl implements ProductCommandService {
         productRepository.save(product);
 
         return ProductConverter.toProductResDTO(product);
+    }
+
+    @Override
+    public void deleteProduct(Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        productRepository.delete(product);
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/service/query/ProductQueryService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/service/query/ProductQueryService.java
@@ -4,5 +4,8 @@ import com.project.likelion13thbe.domain.product.dto.response.ProductResDTO;
 
 public interface ProductQueryService {
     public ProductResDTO.ProductDetailResDTO getProduct(Long productId);
+
     public ProductResDTO.ProductListResDTO getProductList();
+
+    public ProductResDTO.ProductCursorResDTO getProductCursor(Long cursor, Integer size);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/service/query/ProductQueryService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/service/query/ProductQueryService.java
@@ -3,9 +3,9 @@ package com.project.likelion13thbe.domain.product.service.query;
 import com.project.likelion13thbe.domain.product.dto.response.ProductResDTO;
 
 public interface ProductQueryService {
-    public ProductResDTO.ProductDetailResDTO getProduct(Long productId);
+    ProductResDTO.ProductDetailResDTO getProduct(Long productId);
 
-    public ProductResDTO.ProductListResDTO getProductList();
+    ProductResDTO.ProductListResDTO getProductList();
 
-    public ProductResDTO.ProductCursorResDTO getProductCursor(Long cursor, Integer size);
+    ProductResDTO.ProductCursorResDTO getProductCursor(Long cursor, Integer size);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/service/query/ProductQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/service/query/ProductQueryServiceImpl.java
@@ -7,6 +7,9 @@ import com.project.likelion13thbe.domain.product.exception.ProductErrorCode;
 import com.project.likelion13thbe.domain.product.exception.ProductException;
 import com.project.likelion13thbe.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +45,20 @@ public class ProductQueryServiceImpl implements ProductQueryService {
                         .toList();
 
         return ProductConverter.toProductListResDTO(productDetailResDTOList);
+    }
+
+    @Override
+    public ProductResDTO.ProductCursorResDTO getProductCursor(Long cursor, Integer size) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        // cursor가 0일 경우(첫페이지) cursor 최대값
+        if (cursor == 0) {
+            cursor = Long.MAX_VALUE;
+        }
+
+        Slice<ProductDetailDTO> productDetailDTOSlice = productRepository.findAllByProductIdLessThanOrderByProductIdDesc(cursor, pageable);
+
+        return ProductConverter.toProductCursorResDTO(productDetailDTOSlice);
     }
 
 }

--- a/src/main/java/com/project/likelion13thbe/domain/product/service/query/ProductQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/service/query/ProductQueryServiceImpl.java
@@ -3,6 +3,8 @@ package com.project.likelion13thbe.domain.product.service.query;
 import com.project.likelion13thbe.domain.product.converter.ProductConverter;
 import com.project.likelion13thbe.domain.product.dto.ProductDetailDTO;
 import com.project.likelion13thbe.domain.product.dto.response.ProductResDTO;
+import com.project.likelion13thbe.domain.product.exception.ProductErrorCode;
+import com.project.likelion13thbe.domain.product.exception.ProductException;
 import com.project.likelion13thbe.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,7 +21,7 @@ public class ProductQueryServiceImpl implements ProductQueryService {
     @Override
     public ProductResDTO.ProductDetailResDTO getProduct(Long productId) {
         ProductDetailDTO productDetailDTO = productRepository.findProductWithReviewStats(productId)
-                .orElseThrow(() -> new RuntimeException("Product가 존재하지 않음"));
+                .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         return ProductConverter.toProductDetailResDTO(
                 productDetailDTO.product(), productDetailDTO.ratingAvg(), productDetailDTO.reviewCount().intValue());
@@ -30,7 +32,7 @@ public class ProductQueryServiceImpl implements ProductQueryService {
         List<ProductDetailDTO> productDetailDTOList = productRepository.findAllProductsWithReviewStats();
 
         if (productDetailDTOList.isEmpty()) {
-            throw new RuntimeException("Product가 존재하지 않음");
+            throw new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND);
         }
 
         List<ProductResDTO.ProductDetailResDTO> productDetailResDTOList =

--- a/src/main/java/com/project/likelion13thbe/domain/product/service/query/ProductQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/product/service/query/ProductQueryServiceImpl.java
@@ -20,7 +20,7 @@ public class ProductQueryServiceImpl implements ProductQueryService {
 
     @Override
     public ProductResDTO.ProductDetailResDTO getProduct(Long productId) {
-        ProductDetailDTO productDetailDTO = productRepository.findProductWithReviewStats(productId)
+        ProductDetailDTO productDetailDTO = productRepository.findProductWithReviewStatsAndNotDeleted(productId)
                 .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         return ProductConverter.toProductDetailResDTO(
@@ -29,7 +29,7 @@ public class ProductQueryServiceImpl implements ProductQueryService {
 
     @Override
     public ProductResDTO.ProductListResDTO getProductList() {
-        List<ProductDetailDTO> productDetailDTOList = productRepository.findAllProductsWithReviewStats();
+        List<ProductDetailDTO> productDetailDTOList = productRepository.findAllProductsWithReviewStatsAndNotDeleted();
 
         if (productDetailDTOList.isEmpty()) {
             throw new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND);

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -7,6 +7,7 @@ import com.project.likelion13thbe.domain.review.service.query.ReviewQueryService
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -35,7 +36,8 @@ public class ReviewController {
     @Operation(summary = "리뷰 작성")
     @PostMapping("products/{productId}/reviews")
     public CustomResponse<ReviewResDTO.ReviewCreateResDTO> createReview(
-            @PathVariable Long productId, @RequestBody ReviewReqDTO.ReviewCreateReqDTO reviewCreateReqDTO) {
+            @PathVariable Long productId,
+            @RequestBody @Valid ReviewReqDTO.ReviewCreateReqDTO reviewCreateReqDTO) {
         return CustomResponse.onSuccess(HttpStatus.CREATED, reviewCommandService.createReview(reviewCreateReqDTO, productId));
     }
 

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -45,7 +45,7 @@ public class ReviewController {
     @PatchMapping("reviews/{reviewId}")
     public CustomResponse<String> updateReview(
             @PathVariable Long reviewId,
-            @RequestBody ReviewReqDTO.ReviewUpdateReqDTO reviewUpdateReqDTO) {
+            @RequestBody @Valid ReviewReqDTO.ReviewUpdateReqDTO reviewUpdateReqDTO) {
 
         reviewCommandService.updateReview(reviewUpdateReqDTO, reviewId);
 

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -66,4 +66,14 @@ public class ReviewController {
     public CustomResponse<ReviewResDTO.ReviewListResDTO> getMyReviews() {
         return CustomResponse.onSuccess(reviewQueryService.getMyReviewList());
     }
+
+    @Operation(summary = "리뷰 목록 조회 (커서 방식)")
+    @GetMapping("products/{productId}/reviews-cursor/")
+    public CustomResponse<ReviewResDTO.ReviewCursorResDTO> getReviewCursor(
+            @PathVariable Long productId,
+            @RequestParam Long cursor,
+            @RequestParam Integer size
+    ) {
+        return CustomResponse.onSuccess(reviewQueryService.getReviewCursor(productId, cursor, size));
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -6,9 +6,6 @@ import com.project.likelion13thbe.domain.review.service.command.ReviewCommandSer
 import com.project.likelion13thbe.domain.review.service.query.ReviewQueryService;
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -45,8 +42,13 @@ public class ReviewController {
 
     @Operation(summary = "리뷰 수정")
     @PatchMapping("reviews/{reviewId}")
-    public ResponseEntity<?> patchReview(@PathVariable Long reviewId, @RequestBody ReviewReqDTO.ReviewUpdateReqDTO reviewUpdateReqDTO) {
-        return null;
+    public CustomResponse<String> updateReview(
+            @PathVariable Long reviewId,
+            @RequestBody ReviewReqDTO.ReviewUpdateReqDTO reviewUpdateReqDTO) {
+
+        reviewCommandService.updateReview(reviewUpdateReqDTO, reviewId);
+
+        return CustomResponse.onSuccess("리뷰 수정 완료");
     }
 
     @Operation(summary = "리뷰 삭제")

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -53,8 +53,11 @@ public class ReviewController {
 
     @Operation(summary = "리뷰 삭제")
     @DeleteMapping("reviews/{reviewId}")
-    public ResponseEntity<?> deleteReview(@PathVariable Long reviewId) {
-        return null;
+    public CustomResponse<String> deleteReview(@PathVariable Long reviewId) {
+
+        reviewCommandService.deleteReview(reviewId);
+
+        return CustomResponse.onSuccess(HttpStatus.NO_CONTENT, "리뷰 삭제 완료");
     }
 
     @Operation(summary = "내 리뷰 조회")

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -38,11 +38,9 @@ public class ReviewController {
 
     @Operation(summary = "리뷰 작성")
     @PostMapping("products/{productId}/reviews")
-    public ResponseEntity<ReviewResDTO.ReviewCreateResDTO> createReview(
+    public CustomResponse<ReviewResDTO.ReviewCreateResDTO> createReview(
             @PathVariable Long productId, @RequestBody ReviewReqDTO.ReviewCreateReqDTO reviewCreateReqDTO) {
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(reviewCommandService.createReview(reviewCreateReqDTO, productId));
+        return CustomResponse.onSuccess(HttpStatus.CREATED, reviewCommandService.createReview(reviewCreateReqDTO, productId));
     }
 
     @Operation(summary = "리뷰 수정")

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -24,40 +24,18 @@ public class ReviewController {
     private final ReviewQueryService reviewQueryService;
 
     @Operation(summary = "리뷰 세부 조회")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "OK",
-//                    content = @Content(mediaType = "application/json",
-//                            schema = @Schema(implementation = ReviewResDTO.ReviewDetailResDTO.class))),
-//            @ApiResponse(responseCode = "404", description = "Not Found",
-//                    content = @Content(mediaType = "application/json"))
-//    })
     @GetMapping("reviews/{reviewId}")
     public ResponseEntity<ReviewResDTO.ReviewDetailResDTO> getReview(@PathVariable Long reviewId) {
         return ResponseEntity.ok(reviewQueryService.getReview(reviewId));
     }
 
     @Operation(summary = "리뷰 목록 조회")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "OK",
-//                    content = @Content(mediaType = "application/json",
-//                            schema = @Schema(implementation = ReviewResDTO.ReviewListResDTO.class))),
-//            @ApiResponse(responseCode = "404", description = "Not Found",
-//                    content = @Content(mediaType = "application/json"))
-//    })
     @GetMapping("products/{productId}/reviews")
     public ResponseEntity<ReviewResDTO.ReviewListResDTO> getReviewList(@PathVariable Long productId) {
         return ResponseEntity.ok(reviewQueryService.getReviewList(productId));
     }
 
     @Operation(summary = "리뷰 작성")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "201", description = "Created",
-//                    content = @Content(mediaType = "application/json")),
-//            @ApiResponse(responseCode = "400", description = "Bad Request",
-//                    content = @Content(mediaType = "application/json")),
-//            @ApiResponse(responseCode = "404", description = "Not Found",
-//                    content = @Content(mediaType = "application/json"))
-//    })
     @PostMapping("products/{productId}/reviews")
     public ResponseEntity<ReviewResDTO.ReviewCreateResDTO> createReview(
             @PathVariable Long productId, @RequestBody ReviewReqDTO.ReviewCreateReqDTO reviewCreateReqDTO) {
@@ -67,39 +45,18 @@ public class ReviewController {
     }
 
     @Operation(summary = "리뷰 수정")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "OK",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "Bad Request",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "404", description = "Not Found",
-                    content = @Content(mediaType = "application/json"))
-    })
     @PatchMapping("reviews/{reviewId}")
     public ResponseEntity<?> patchReview(@PathVariable Long reviewId, @RequestBody ReviewReqDTO.ReviewUpdateReqDTO reviewUpdateReqDTO) {
         return null;
     }
 
     @Operation(summary = "리뷰 삭제")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "No Content",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "404", description = "Not Found",
-                    content = @Content(mediaType = "application/json"))
-    })
     @DeleteMapping("reviews/{reviewId}")
     public ResponseEntity<?> deleteReview(@PathVariable Long reviewId) {
         return null;
     }
 
     @Operation(summary = "내 리뷰 조회")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "OK",
-//                    content = @Content(mediaType = "application/json",
-//                            schema = @Schema(implementation = ReviewResDTO.ReviewListResDTO.class))),
-//            @ApiResponse(responseCode = "401", description = "Unauthorized",
-//                    content = @Content(mediaType = "application/json"))
-//    })
     @GetMapping("/reviews/my")
     public ResponseEntity<ReviewResDTO.ReviewListResDTO> getMyReviews() {
         return ResponseEntity.ok(reviewQueryService.getMyReviewList());

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -4,6 +4,7 @@ import com.project.likelion13thbe.domain.review.dto.request.ReviewReqDTO;
 import com.project.likelion13thbe.domain.review.dto.response.ReviewResDTO;
 import com.project.likelion13thbe.domain.review.service.command.ReviewCommandService;
 import com.project.likelion13thbe.domain.review.service.query.ReviewQueryService;
+import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -25,14 +26,14 @@ public class ReviewController {
 
     @Operation(summary = "리뷰 세부 조회")
     @GetMapping("reviews/{reviewId}")
-    public ResponseEntity<ReviewResDTO.ReviewDetailResDTO> getReview(@PathVariable Long reviewId) {
-        return ResponseEntity.ok(reviewQueryService.getReview(reviewId));
+    public CustomResponse<ReviewResDTO.ReviewDetailResDTO> getReview(@PathVariable Long reviewId) {
+        return CustomResponse.onSuccess(reviewQueryService.getReview(reviewId));
     }
 
     @Operation(summary = "리뷰 목록 조회")
     @GetMapping("products/{productId}/reviews")
-    public ResponseEntity<ReviewResDTO.ReviewListResDTO> getReviewList(@PathVariable Long productId) {
-        return ResponseEntity.ok(reviewQueryService.getReviewList(productId));
+    public CustomResponse<ReviewResDTO.ReviewListResDTO> getReviewList(@PathVariable Long productId) {
+        return CustomResponse.onSuccess(reviewQueryService.getReviewList(productId));
     }
 
     @Operation(summary = "리뷰 작성")
@@ -58,7 +59,7 @@ public class ReviewController {
 
     @Operation(summary = "내 리뷰 조회")
     @GetMapping("/reviews/my")
-    public ResponseEntity<ReviewResDTO.ReviewListResDTO> getMyReviews() {
-        return ResponseEntity.ok(reviewQueryService.getMyReviewList());
+    public CustomResponse<ReviewResDTO.ReviewListResDTO> getMyReviews() {
+        return CustomResponse.onSuccess(reviewQueryService.getMyReviewList());
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/converter/ReviewConverter.java
@@ -7,6 +7,7 @@ import com.project.likelion13thbe.domain.review.dto.response.ReviewResDTO;
 import com.project.likelion13thbe.domain.review.entity.Review;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
@@ -47,4 +48,23 @@ public class ReviewConverter {
                 .reviewList(reviewList)
                 .build();
     }
+
+    public static ReviewResDTO.ReviewCursorResDTO toReviewCursorResDTO(Slice<Review> reviews) {
+        List<ReviewResDTO.ReviewDetailResDTO> reviewList = reviews.stream()
+                .map(ReviewConverter::toReviewDetailResDTO)
+                .toList();
+
+        // 다음 cursor 지정
+        Long nextCursor = null;
+        if (!reviews.isEmpty() && reviews.hasNext()) {
+            nextCursor = reviews.getContent().get(reviews.getNumberOfElements() - 1).getReviewId();
+        }
+
+        return ReviewResDTO.ReviewCursorResDTO.builder()
+                .reviews(reviewList)
+                .hasNext(reviews.hasNext())
+                .nextCursor(nextCursor)
+                .build();
+    }
+
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/dto/request/ReviewReqDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/dto/request/ReviewReqDTO.java
@@ -14,6 +14,7 @@ public class ReviewReqDTO {
     }
 
     public record ReviewUpdateReqDTO(
+            @NotNull(message = "별점은 필수 입력값입니다.")
             Double rating,
             String content
     ) {

--- a/src/main/java/com/project/likelion13thbe/domain/review/dto/request/ReviewReqDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/dto/request/ReviewReqDTO.java
@@ -1,10 +1,13 @@
 package com.project.likelion13thbe.domain.review.dto.request;
 
 
+import jakarta.validation.constraints.NotNull;
+
 public class ReviewReqDTO {
 
     public record ReviewCreateReqDTO(
             Long memberId,
+            @NotNull(message = "별점은 필수 입력값입니다.")
             Double rating,
             String content
     ) {

--- a/src/main/java/com/project/likelion13thbe/domain/review/dto/response/ReviewResDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/dto/response/ReviewResDTO.java
@@ -34,4 +34,12 @@ public class ReviewResDTO {
     ) {
     }
 
+    @Builder
+    public record ReviewCursorResDTO(
+            List<ReviewResDTO.ReviewDetailResDTO> reviews,
+            Long nextCursor,
+            Boolean hasNext
+    ) {
+    }
+
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/dto/response/ReviewResDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/dto/response/ReviewResDTO.java
@@ -1,6 +1,6 @@
 package com.project.likelion13thbe.domain.review.dto.response;
 
-import lombok.*;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/project/likelion13thbe/domain/review/entity/Review.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/entity/Review.java
@@ -6,6 +6,8 @@ import com.project.likelion13thbe.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -31,9 +33,18 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "product_id")
     private Product product;
 
+    // soft delete를 위한 필드 추가
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     // 리뷰 변경 메소드
     public void updateReview(Double rating, String content) {
         this.rating = rating;
         this.content = content;
+    }
+
+    // soft delete 메서드
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/entity/Review.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/entity/Review.java
@@ -30,4 +30,10 @@ public class Review extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
+
+    // 리뷰 변경 메소드
+    public void updateReview(Double rating, String content) {
+        this.rating = rating;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/exception/ReviewErrorCode.java
@@ -1,0 +1,16 @@
+package com.project.likelion13thbe.domain.review.exception;
+
+import com.project.likelion13thbe.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewErrorCode implements BaseErrorCode {
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "리뷰를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/likelion13thbe/domain/review/exception/ReviewException.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/exception/ReviewException.java
@@ -1,0 +1,9 @@
+package com.project.likelion13thbe.domain.review.exception;
+
+import com.project.likelion13thbe.global.apiPayload.exception.CustomException;
+
+public class ReviewException extends CustomException {
+    public ReviewException(ReviewErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
@@ -1,11 +1,14 @@
 package com.project.likelion13thbe.domain.review.repository;
 
+import com.project.likelion13thbe.domain.member.entity.Member;
 import com.project.likelion13thbe.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
@@ -15,4 +18,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     // 이런 식으로 안하는 것을 알고는 있지만 일단 토큰 방식을 몰라서 내 리뷰 조회가 작동만 할 수 있게 작성했습니다
     @Query("SELECT r FROM Review r WHERE r.member.memberId = :memberId")
     List<Review> findAllReviewsByMemberId(Long memberId);
+
+    // 삭제되지 않은 리뷰를 리뷰 아이디로 조회
+    @Query("SELECT r " +
+            "FROM Review r " +
+            "WHERE r.reviewId = :reviewId AND r.deletedAt IS NULL")
+    Optional<Review> findByReviewIdAndNotDeleted(@Param("reviewId") Long reviewId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,5 @@
 package com.project.likelion13thbe.domain.review.repository;
 
-import com.project.likelion13thbe.domain.member.entity.Member;
 import com.project.likelion13thbe.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,12 +11,16 @@ import java.util.Optional;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    @Query("SELECT r FROM Review r WHERE r.product.productId = :productId")
-    List<Review> findAllReviewsByProductId(Long productId);
+    @Query("SELECT r " +
+            "FROM Review r " +
+            "WHERE r.product.productId = :productId AND r.deletedAt IS NULL")
+    List<Review> findAllReviewsByProductIdAndNotDeleted(Long productId);
 
     // 이런 식으로 안하는 것을 알고는 있지만 일단 토큰 방식을 몰라서 내 리뷰 조회가 작동만 할 수 있게 작성했습니다
-    @Query("SELECT r FROM Review r WHERE r.member.memberId = :memberId")
-    List<Review> findAllReviewsByMemberId(Long memberId);
+    @Query("SELECT r " +
+            "FROM Review r " +
+            "WHERE r.member.memberId = :memberId AND r.deletedAt IS NULL")
+    List<Review> findAllReviewsByMemberIdAndNotDeleted(Long memberId);
 
     // 삭제되지 않은 리뷰를 리뷰 아이디로 조회
     @Query("SELECT r " +

--- a/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,5 @@
 package com.project.likelion13thbe.domain.review.repository;
 
-import com.project.likelion13thbe.domain.member.entity.Member;
 import com.project.likelion13thbe.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
@@ -1,11 +1,13 @@
 package com.project.likelion13thbe.domain.review.repository;
 
+import com.project.likelion13thbe.domain.member.entity.Member;
 import com.project.likelion13thbe.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,4 +29,11 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "FROM Review r " +
             "WHERE r.reviewId = :reviewId AND r.deletedAt IS NULL")
     Optional<Review> findByReviewIdAndNotDeleted(@Param("reviewId") Long reviewId);
+
+    // 소프트 딜리트된 지 7일 지난 리뷰 조회
+    @Query("SELECT r " +
+            "FROM Review r " +
+            "WHERE r.deletedAt IS NOT NULL AND r.deletedAt <= :oneWeekAgo")
+    List<Review> findDeletedReviewsBefore(@Param("oneWeekAgo") LocalDateTime oneWeekAgo);
+
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,8 @@
 package com.project.likelion13thbe.domain.review.repository;
 
 import com.project.likelion13thbe.domain.review.entity.Review;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -34,5 +36,13 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "FROM Review r " +
             "WHERE r.deletedAt IS NOT NULL AND r.deletedAt <= :oneWeekAgo")
     List<Review> findDeletedReviewsBefore(@Param("oneWeekAgo") LocalDateTime oneWeekAgo);
+
+    // cursor
+    @Query("SELECT r " +
+            "FROM Review r " +
+            "WHERE r.product.productId = :reviewId AND r.reviewId < :cursor AND r.deletedAt IS NULL " +
+            "ORDER BY r.reviewId DESC")
+    Slice<Review> findAllReviewByProductIdLessThanOrderByReviewIdDesc(
+            @Param("reviewId") Long reviewId, @Param("cursor") Long cursor, Pageable pageable);
 
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
@@ -4,9 +4,9 @@ import com.project.likelion13thbe.domain.review.dto.request.ReviewReqDTO;
 import com.project.likelion13thbe.domain.review.dto.response.ReviewResDTO;
 
 public interface ReviewCommandService {
-    public ReviewResDTO.ReviewCreateResDTO createReview(ReviewReqDTO.ReviewCreateReqDTO reviewCreateReqDTO, Long productId);
+    ReviewResDTO.ReviewCreateResDTO createReview(ReviewReqDTO.ReviewCreateReqDTO reviewCreateReqDTO, Long productId);
 
-    public void updateReview(ReviewReqDTO.ReviewUpdateReqDTO reviewUpdateReqDTO, Long reviewId);
+    void updateReview(ReviewReqDTO.ReviewUpdateReqDTO reviewUpdateReqDTO, Long reviewId);
 
-    public void deleteReview(Long reviewId);
+    void deleteReview(Long reviewId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
@@ -7,4 +7,6 @@ public interface ReviewCommandService {
     public ReviewResDTO.ReviewCreateResDTO createReview(ReviewReqDTO.ReviewCreateReqDTO reviewCreateReqDTO, Long productId);
 
     public void updateReview(ReviewReqDTO.ReviewUpdateReqDTO reviewUpdateReqDTO, Long reviewId);
+
+    public void deleteReview(Long reviewId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
@@ -5,4 +5,6 @@ import com.project.likelion13thbe.domain.review.dto.response.ReviewResDTO;
 
 public interface ReviewCommandService {
     public ReviewResDTO.ReviewCreateResDTO createReview(ReviewReqDTO.ReviewCreateReqDTO reviewCreateReqDTO, Long productId);
+
+    public void updateReview(ReviewReqDTO.ReviewUpdateReqDTO reviewUpdateReqDTO, Long reviewId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -48,4 +48,12 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
 
         review.updateReview(reviewUpdateReqDTO.rating(), reviewUpdateReqDTO.content());
     }
+
+    @Override
+    public void deleteReview(Long reviewId) {
+        Review review = reviewRepository.findByReviewIdAndNotDeleted(reviewId)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
+        review.delete();
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -16,9 +16,15 @@ import com.project.likelion13thbe.domain.review.exception.ReviewErrorCode;
 import com.project.likelion13thbe.domain.review.exception.ReviewException;
 import com.project.likelion13thbe.domain.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -55,5 +61,32 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
         review.delete();
+    }
+
+    @Scheduled(cron = "0 0 6 * * *")
+    @Transactional
+    public void cleanupDeletedReview() {
+        log.info("삭제된 리뷰를 제거하는 스케쥴 시작");
+
+        // 일주일 전 날짜 계산
+        LocalDateTime oneWeekAgo = LocalDateTime.now().minusWeeks(1);
+
+        // 일주일 전 이전에 소프트 딜리트된 리뷰 조회
+        List<Review> reviewsToDelete = reviewRepository.findDeletedReviewsBefore(oneWeekAgo);
+
+        if (reviewsToDelete.isEmpty()) {
+            log.info("제거할 리뷰가 없습니다.");
+            return;
+        }
+        for (Review review : reviewsToDelete) {
+            try {
+                log.info("리뷰 삭제 시도: id={}", review.getReviewId());
+                reviewRepository.delete(review);
+                log.info("리뷰 삭제 성공: id={}", review.getReviewId());
+            } catch (Exception e) {
+                log.error("리뷰 삭제 실패: id={}, 이유={}", review.getReviewId(), e.getMessage());
+            }
+        }
+        log.info("삭제가 완료되었습니다.\n");
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -43,7 +43,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
 
     @Override
     public void updateReview(ReviewReqDTO.ReviewUpdateReqDTO reviewUpdateReqDTO, Long reviewId) {
-        Review review = reviewRepository.findById(reviewId)
+        Review review = reviewRepository.findByReviewIdAndNotDeleted(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
         review.updateReview(reviewUpdateReqDTO.rating(), reviewUpdateReqDTO.content());

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -12,6 +12,8 @@ import com.project.likelion13thbe.domain.review.converter.ReviewConverter;
 import com.project.likelion13thbe.domain.review.dto.request.ReviewReqDTO;
 import com.project.likelion13thbe.domain.review.dto.response.ReviewResDTO;
 import com.project.likelion13thbe.domain.review.entity.Review;
+import com.project.likelion13thbe.domain.review.exception.ReviewErrorCode;
+import com.project.likelion13thbe.domain.review.exception.ReviewException;
 import com.project.likelion13thbe.domain.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,11 +33,19 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
-        
+
         Review review = ReviewConverter.toReview(reviewCreateReqDTO, member, product);
 
         reviewRepository.save(review);
 
         return ReviewConverter.toReviewCreateResDTO(review);
+    }
+
+    @Override
+    public void updateReview(ReviewReqDTO.ReviewUpdateReqDTO reviewUpdateReqDTO, Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
+        review.updateReview(reviewUpdateReqDTO.rating(), reviewUpdateReqDTO.content());
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -1,8 +1,12 @@
 package com.project.likelion13thbe.domain.review.service.command;
 
 import com.project.likelion13thbe.domain.member.entity.Member;
+import com.project.likelion13thbe.domain.member.exception.MemberErrorCode;
+import com.project.likelion13thbe.domain.member.exception.MemberException;
 import com.project.likelion13thbe.domain.member.repository.MemberRepository;
 import com.project.likelion13thbe.domain.product.entity.Product;
+import com.project.likelion13thbe.domain.product.exception.ProductErrorCode;
+import com.project.likelion13thbe.domain.product.exception.ProductException;
 import com.project.likelion13thbe.domain.product.repository.ProductRepository;
 import com.project.likelion13thbe.domain.review.converter.ReviewConverter;
 import com.project.likelion13thbe.domain.review.dto.request.ReviewReqDTO;
@@ -24,9 +28,9 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     @Override
     public ReviewResDTO.ReviewCreateResDTO createReview(ReviewReqDTO.ReviewCreateReqDTO reviewCreateReqDTO, Long productId) {
         Member member = memberRepository.findById(reviewCreateReqDTO.memberId())
-                .orElseThrow(() -> new RuntimeException("Member가 존재하지 않음"));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
         Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new RuntimeException("Product가 존재하지 않음"));
+                .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
         
         Review review = ReviewConverter.toReview(reviewCreateReqDTO, member, product);
 

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryService.java
@@ -3,11 +3,11 @@ package com.project.likelion13thbe.domain.review.service.query;
 import com.project.likelion13thbe.domain.review.dto.response.ReviewResDTO;
 
 public interface ReviewQueryService {
-    public ReviewResDTO.ReviewDetailResDTO getReview(Long reviewId);
+    ReviewResDTO.ReviewDetailResDTO getReview(Long reviewId);
 
-    public ReviewResDTO.ReviewListResDTO getReviewList(Long productId);
+    ReviewResDTO.ReviewListResDTO getReviewList(Long productId);
 
-    public ReviewResDTO.ReviewListResDTO getMyReviewList();
+    ReviewResDTO.ReviewListResDTO getMyReviewList();
 
-    public ReviewResDTO.ReviewCursorResDTO getReviewCursor(Long productId, Long cursor, Integer size);
+    ReviewResDTO.ReviewCursorResDTO getReviewCursor(Long productId, Long cursor, Integer size);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryService.java
@@ -8,4 +8,6 @@ public interface ReviewQueryService {
     public ReviewResDTO.ReviewListResDTO getReviewList(Long productId);
 
     public ReviewResDTO.ReviewListResDTO getMyReviewList();
+
+    public ReviewResDTO.ReviewCursorResDTO getReviewCursor(Long productId, Long cursor, Integer size);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -20,14 +20,14 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
 
     @Override
     public ReviewResDTO.ReviewDetailResDTO getReview(Long reviewId) {
-        Review review = reviewRepository.findById(reviewId)
+        Review review = reviewRepository.findByReviewIdAndNotDeleted(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
         return ReviewConverter.toReviewDetailResDTO(review);
     }
 
     @Override
     public ReviewResDTO.ReviewListResDTO getReviewList(Long productId) {
-        List<Review> reviewList = reviewRepository.findAllReviewsByProductId(productId);
+        List<Review> reviewList = reviewRepository.findAllReviewsByProductIdAndNotDeleted(productId);
         if (reviewList.isEmpty()) {
             throw new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND);
         }
@@ -42,7 +42,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
 
     @Override
     public ReviewResDTO.ReviewListResDTO getMyReviewList() {
-        List<Review> reviewList = reviewRepository.findAllReviewsByMemberId(1L);
+        List<Review> reviewList = reviewRepository.findAllReviewsByMemberIdAndNotDeleted(1L);
         // 이게 상품별 리뷰 조회는 Path Variable로 받아왔는데,
         // 내 리뷰는 아직 토큰 구별 기능 불가능 이슈로 상수 넣었습니다
         if (reviewList.isEmpty()) {

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -7,6 +7,9 @@ import com.project.likelion13thbe.domain.review.exception.ReviewErrorCode;
 import com.project.likelion13thbe.domain.review.exception.ReviewException;
 import com.project.likelion13thbe.domain.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,4 +60,17 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
         return ReviewConverter.toReviewListResDTO(filteredReviewsDetailResDTOList);
     }
 
+    @Override
+    public ReviewResDTO.ReviewCursorResDTO getReviewCursor(Long productId, Long cursor, Integer size) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        // cursor가 0일 경우(첫페이지) cursor 최대값
+        if (cursor == 0) {
+            cursor = Long.MAX_VALUE;
+        }
+
+        Slice<Review> reviews = reviewRepository.findAllReviewByProductIdLessThanOrderByReviewIdDesc(productId, cursor, pageable);
+
+        return ReviewConverter.toReviewCursorResDTO(reviews);
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -3,6 +3,8 @@ package com.project.likelion13thbe.domain.review.service.query;
 import com.project.likelion13thbe.domain.review.converter.ReviewConverter;
 import com.project.likelion13thbe.domain.review.dto.response.ReviewResDTO;
 import com.project.likelion13thbe.domain.review.entity.Review;
+import com.project.likelion13thbe.domain.review.exception.ReviewErrorCode;
+import com.project.likelion13thbe.domain.review.exception.ReviewException;
 import com.project.likelion13thbe.domain.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,7 +21,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     @Override
     public ReviewResDTO.ReviewDetailResDTO getReview(Long reviewId) {
         Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new RuntimeException("Review가 존재하지 않음"));
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
         return ReviewConverter.toReviewDetailResDTO(review);
     }
 
@@ -27,7 +29,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     public ReviewResDTO.ReviewListResDTO getReviewList(Long productId) {
         List<Review> reviewList = reviewRepository.findAllReviewsByProductId(productId);
         if (reviewList.isEmpty()) {
-            throw new RuntimeException("review가 존재하지 않음");
+            throw new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND);
         }
 
         List<ReviewResDTO.ReviewDetailResDTO> filteredReviewsDetailResDTOList =
@@ -44,7 +46,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
         // 이게 상품별 리뷰 조회는 Path Variable로 받아왔는데,
         // 내 리뷰는 아직 토큰 구별 기능 불가능 이슈로 상수 넣었습니다
         if (reviewList.isEmpty()) {
-            throw new RuntimeException("review가 존재하지 않음");
+            throw new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND);
         }
 
         List<ReviewResDTO.ReviewDetailResDTO> filteredReviewsDetailResDTOList =

--- a/src/main/java/com/project/likelion13thbe/global/apiPayload/CustomResponse.java
+++ b/src/main/java/com/project/likelion13thbe/global/apiPayload/CustomResponse.java
@@ -1,0 +1,44 @@
+package com.project.likelion13thbe.global.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class CustomResponse<T> {
+
+    @JsonProperty("isSuccess") // isSuccess라는 변수라는 것을 명시하는 Annotation
+    private boolean isSuccess;
+
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("result")
+    private final T result;
+
+    //기본적으로 200 OK를 사용하는 성공 응답 생성 메서드
+    public static <T> CustomResponse<T> onSuccess(T result) {
+        return new CustomResponse<>(true, String.valueOf(HttpStatus.OK.value()), HttpStatus.OK.getReasonPhrase(), result);
+    }
+
+    //상태 코드를 받아서 사용하는 성공 응답 생성 메서드
+    public static <T> CustomResponse<T> onSuccess(HttpStatus status, T result) {
+        return new CustomResponse<>(true, String.valueOf(status.value()), status.getReasonPhrase(), result);
+    }
+
+    //실패 응답 생성 메서드 (데이터 포함)
+    public static <T> CustomResponse<T> onFailure(String code, String message, T result) {
+        return new CustomResponse<>(false, code, message, result);
+    }
+
+    //실패 응답 생성 메서드 (데이터 없음)
+    public static <T> CustomResponse<T> onFailure(String code, String message) {
+        return new CustomResponse<>(false, code, message, null);
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/global/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,15 @@
+package com.project.likelion13thbe.global.apiPayload.code;
+
+import com.project.likelion13thbe.global.apiPayload.CustomResponse;
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+
+    default CustomResponse<Void> getErrorResponse() {
+        return CustomResponse.onFailure(getCode(), getMessage());
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/global/apiPayload/code/GeneralErrorCode.java
@@ -1,0 +1,29 @@
+package com.project.likelion13thbe.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum GeneralErrorCode implements BaseErrorCode{
+
+    BAD_REQUEST_400(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다"),
+
+    UNAUTHORIZED_401(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다"),
+
+    FORBIDDEN_403(HttpStatus.FORBIDDEN, "COMMON403", "접근이 금지되었습니다"),
+
+    NOT_FOUND_404(HttpStatus.NOT_FOUND, "COMMON404", "요청한 자원을 찾을 수 없습니다"),
+
+    INTERNAL_SERVER_ERROR_500(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 내부 오류가 발생했습니다"),
+
+    // 유효성 검사
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALID400_0", "잘못된 파라미터 입니다.")
+    ;
+
+    // 필요한 필드값 선언
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/likelion13thbe/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/global/apiPayload/code/GeneralErrorCode.java
@@ -20,6 +20,7 @@ public enum GeneralErrorCode implements BaseErrorCode{
 
     // 유효성 검사
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALID400_0", "잘못된 파라미터 입니다.")
+    VALIDATION_FAILED_DTO_FILED(HttpStatus.BAD_REQUEST, "VALID400_1", "잘못된 ReqDTO 입니다."),
     ;
 
     // 필요한 필드값 선언

--- a/src/main/java/com/project/likelion13thbe/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/global/apiPayload/code/GeneralErrorCode.java
@@ -19,8 +19,8 @@ public enum GeneralErrorCode implements BaseErrorCode{
     INTERNAL_SERVER_ERROR_500(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 내부 오류가 발생했습니다"),
 
     // 유효성 검사
-    VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALID400_0", "잘못된 파라미터 입니다.")
     VALIDATION_FAILED_DTO_FILED(HttpStatus.BAD_REQUEST, "VALID400_1", "잘못된 ReqDTO 입니다."),
+    VALIDATION_FAILED_PARAM(HttpStatus.BAD_REQUEST, "VALID400_2", "잘못된 파라미터 입니다."),
     ;
 
     // 필요한 필드값 선언

--- a/src/main/java/com/project/likelion13thbe/global/apiPayload/exception/CustomException.java
+++ b/src/main/java/com/project/likelion13thbe/global/apiPayload/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.project.likelion13thbe.global.apiPayload.exception;
+
+import com.project.likelion13thbe.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+
+    private final BaseErrorCode code;
+
+    public CustomException(BaseErrorCode errorCode) {
+        this.code = errorCode;
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/apiPayload/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/likelion13thbe/global/apiPayload/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.project.likelion13thbe.global.apiPayload.exception.handler;
+
+import com.project.likelion13thbe.global.apiPayload.CustomResponse;
+import com.project.likelion13thbe.global.apiPayload.code.BaseErrorCode;
+import com.project.likelion13thbe.global.apiPayload.code.GeneralErrorCode;
+import com.project.likelion13thbe.global.apiPayload.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    //애플리케이션에서 발생하는 커스텀 예외를 처리
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<CustomResponse<Void>> handleCustomException(CustomException ex) {
+        //예외가 발생하면 로그 기록
+        log.warn("[ CustomException ]: {}", ex.getCode().getMessage());
+        //커스텀 예외에 정의된 에러 코드와 메시지를 포함한 응답 제공
+        return ResponseEntity.status(ex.getCode().getHttpStatus())
+                .body(ex.getCode().getErrorResponse());
+    }
+
+    // 그 외의 정의되지 않은 모든 예외 처리
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<CustomResponse<String>> handleAllException(Exception ex) {
+        log.error("[WARNING] Internal Server Error : {} ", ex.getMessage());
+        BaseErrorCode errorCode = GeneralErrorCode.INTERNAL_SERVER_ERROR_500;
+        CustomResponse<String> errorResponse = CustomResponse.onFailure(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                null
+        );
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(errorResponse);
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/apiPayload/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/likelion13thbe/global/apiPayload/exception/handler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import com.project.likelion13thbe.global.apiPayload.code.BaseErrorCode;
 import com.project.likelion13thbe.global.apiPayload.code.GeneralErrorCode;
 import com.project.likelion13thbe.global.apiPayload.exception.CustomException;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -38,6 +39,24 @@ public class GlobalExceptionHandler {
         });
 
         BaseErrorCode errorCode = GeneralErrorCode.VALIDATION_FAILED_DTO_FILED;
+        CustomResponse<Map<String, String>> errorResponse = CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errors);
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(errorResponse);
+    }
+
+    // ConstraintViolationException
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CustomResponse<Map<String, String>>> handleConstraintViolation(ConstraintViolationException ex) {
+        log.warn("[ Validation Error - ConstraintViolationException ]: {}", ex.getMessage());
+
+        Map<String, String> errors = new HashMap<>();
+        ex.getConstraintViolations().forEach(violation -> {
+            String field = violation.getPropertyPath().toString();
+            errors.put(field, violation.getMessage());
+        });
+
+        BaseErrorCode errorCode = GeneralErrorCode.VALIDATION_FAILED_PARAM;
         CustomResponse<Map<String, String>> errorResponse = CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errors);
         return ResponseEntity
                 .status(errorCode.getHttpStatus())

--- a/src/main/java/com/project/likelion13thbe/global/apiPayload/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/likelion13thbe/global/apiPayload/exception/handler/GlobalExceptionHandler.java
@@ -6,8 +6,12 @@ import com.project.likelion13thbe.global.apiPayload.code.GeneralErrorCode;
 import com.project.likelion13thbe.global.apiPayload.exception.CustomException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
@@ -21,6 +25,23 @@ public class GlobalExceptionHandler {
         //커스텀 예외에 정의된 에러 코드와 메시지를 포함한 응답 제공
         return ResponseEntity.status(ex.getCode().getHttpStatus())
                 .body(ex.getCode().getErrorResponse());
+    }
+
+    // MethodArgumentNotValidException
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CustomResponse<Map<String, String>>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        log.warn("[ Validation Error - MethodArgumentNotValidException ]: {}", ex.getMessage());
+
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error -> {
+            errors.put(error.getField(), error.getDefaultMessage());
+        });
+
+        BaseErrorCode errorCode = GeneralErrorCode.VALIDATION_FAILED_DTO_FILED;
+        CustomResponse<Map<String, String>> errorResponse = CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errors);
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(errorResponse);
     }
 
     // 그 외의 정의되지 않은 모든 예외 처리


### PR DESCRIPTION
# ☝️Issue Number

- #50 

##  📌 개요

- [x] GlobalExceptionHandler에서 ConstraintViolationException 핸들러가 뭔지 알아보고 작성해보기
- [x] 자신의 API 명세서에 맞게 UD API 개발하기
- [x] (선택) 스케줄러가 뭔지 정리 + Member의 논리적 삭제 기한이 30일이 지나면 알아서 삭제되는 코드 짜기
- [x] 그 밖의 자잘구리한 추가사항

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
### 회원가입 이메일 중복 검사에 대해 (31a0dfe8aee43389dc3defd8df90461d25ad200c)
        이게 원래는 위에서 Member 객체를 생성할 때 검사를 해보려고 했는데,
        찾아보니 객체 생성 단에서만 검사를 하면 정말 희박한 확률로 동시에 가입을 하려고 할 때,
        race condition 이슈가 발생할 수 있다고 해서 저장하는 그 순간에 try-catch 문을 작성했습니다.
        최종 방어선은 DB가 지켜야 하니까요 (생각해보면 DB는 동시성 제어가 되니 무조건 승리자가 정해집니다)
        그런데 실제로 회원가입을 했던 경험을 생각해보니 이메일 중복 검사를 하는데요
        A의 이메일 중복 검사 승인 O (DB에 실제로 저장되진 않음) -> A가 회원가입 전체 폼 작성이 오래 걸렸음 + 아직 작성 중
        -> B가 A와 동일한 이메일로 중복 검사 승인 (DB에 저장이 안된 값이니까 승인은 됨)
        -> B가 A보다 폼을 먼저 작성함 -> A는 이메일 중복 검사를 받았음에도 폼을 다 작성하니 unique 조건 에러 발생
        회원 가입은 아무래도 시스템의 쾌적함을 위해서 병렬적으로 발생해야 한다고 생각하는데
        그러면 회원가입 폼을 작성하기 전에 중복 확인을 받는 단계에서 이 이메일이 지금 가입 중에 있다라는
        어느 정도 시간(20~30분)을 갖고 DB에 존재하게 임시 테이블을 작성하는 것도 방법일까요?
        마치 KTX 예약 장바구니에 담아두면 30분 뒤에 자동으로 자리가 풀리는 느낌입니다
        지금 단계에서는 스웨거로 작성해서 병렬 요청이 불가하니 DB 단에서만 예외 처리를 했습니다
        어떠한 다른 방법이 있을런지요?