### PR TITLE
✨ feat: 세미나 6주차 실습 과제 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,14 @@ dependencies {
 
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -90,8 +90,8 @@ public class CommentController {
                     content = @Content(mediaType = "application/json"))
     })
     @DeleteMapping("/comments/{commentId}")
-    public CustomResponse<String> deleteComment(@PathVariable Long commentId) {
-        commentCommandService.deleteComment(commentId);
+    public CustomResponse<String> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        commentCommandService.deleteComment(commentId, userDetails.getMember());
         return CustomResponse.onSuccess("댓글 삭제 성공");
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -76,8 +76,9 @@ public class CommentController {
     @PatchMapping("/comments/{commentId}")
     public CustomResponse<String> editComment(
             @PathVariable Long commentId,
-            @RequestBody CommentRequestDTO.CommentUpdateRequestDTO commentUpdateRequestDTO) {
-        commentCommandService.updateComment(commentId, commentUpdateRequestDTO);
+            @RequestBody CommentRequestDTO.CommentUpdateRequestDTO commentUpdateRequestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        commentCommandService.updateComment(commentId, commentUpdateRequestDTO, userDetails.getMember());
         return CustomResponse.onSuccess("댓글 수정 완료");
     }
 

--- a/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/controller/CommentController.java
@@ -5,6 +5,7 @@ import com.project.likelion13thbe.domain.comment.dto.response.CommentResponseDTO
 import com.project.likelion13thbe.domain.comment.service.command.CommentCommandService;
 import com.project.likelion13thbe.domain.comment.service.query.CommentQueryService;
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
+import com.project.likelion13thbe.global.security.entity.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -54,10 +56,12 @@ public class CommentController {
                     content = @Content(mediaType = "application/json"))
     })
     @PostMapping("/reviews/{reviewId}/comments")
-    public CustomResponse<CommentResponseDTO.CommentCreateResponseDTO> createComment(@PathVariable Long reviewId,
-                                                                                     @RequestBody CommentRequestDTO.CommentCreateRequestDTO commentCreateRequestDTO
-    ) {
-        return CustomResponse.onSuccess(HttpStatus.CREATED, commentCommandService.createComment(reviewId, commentCreateRequestDTO));
+    public CustomResponse<CommentResponseDTO.CommentCreateResponseDTO> createComment(
+            @PathVariable Long reviewId,
+            @RequestBody CommentRequestDTO.CommentCreateRequestDTO commentCreateRequestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+            ) {
+        return CustomResponse.onSuccess(HttpStatus.CREATED, commentCommandService.createComment(reviewId, commentCreateRequestDTO, userDetails.getMember()));
     }
 
     @Operation(summary = "댓글 수정")

--- a/src/main/java/com/project/likelion13thbe/domain/comment/dto/request/CommentRequestDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/dto/request/CommentRequestDTO.java
@@ -6,9 +6,7 @@ public class CommentRequestDTO {
 
     @Builder
     public record CommentCreateRequestDTO(
-            String content,
-
-            Long memberId
+            String content
     ) {
     }
 

--- a/src/main/java/com/project/likelion13thbe/domain/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/exception/CommentErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum CommentErrorCode implements BaseErrorCode {
 
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404_1", "댓글을 찾을 수 없습니다.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404_1", "댓글을 찾을 수 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMENT401_1", "해당 댓글에 대한 권한이 없습니다."),;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
@@ -10,5 +10,5 @@ public interface CommentCommandService {
 
     void updateComment(Long commentId, CommentRequestDTO.CommentUpdateRequestDTO commentUpdateRequestDTO, Member member);
 
-    void deleteComment(Long commentId);
+    void deleteComment(Long commentId, Member member);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
@@ -2,10 +2,11 @@ package com.project.likelion13thbe.domain.comment.service.command;
 
 import com.project.likelion13thbe.domain.comment.dto.request.CommentRequestDTO;
 import com.project.likelion13thbe.domain.comment.dto.response.CommentResponseDTO;
+import com.project.likelion13thbe.domain.member.entity.Member;
 
 public interface CommentCommandService {
 
-    CommentResponseDTO.CommentCreateResponseDTO createComment(Long reviewId, CommentRequestDTO.CommentCreateRequestDTO commentCreateRequestDTO);
+    CommentResponseDTO.CommentCreateResponseDTO createComment(Long reviewId, CommentRequestDTO.CommentCreateRequestDTO commentCreateRequestDTO, Member member);
 
     void updateComment(Long commentId, CommentRequestDTO.CommentUpdateRequestDTO commentUpdateRequestDTO);
 

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandService.java
@@ -8,7 +8,7 @@ public interface CommentCommandService {
 
     CommentResponseDTO.CommentCreateResponseDTO createComment(Long reviewId, CommentRequestDTO.CommentCreateRequestDTO commentCreateRequestDTO, Member member);
 
-    void updateComment(Long commentId, CommentRequestDTO.CommentUpdateRequestDTO commentUpdateRequestDTO);
+    void updateComment(Long commentId, CommentRequestDTO.CommentUpdateRequestDTO commentUpdateRequestDTO, Member member);
 
     void deleteComment(Long commentId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
@@ -8,8 +8,6 @@ import com.project.likelion13thbe.domain.comment.exception.CommentErrorCode;
 import com.project.likelion13thbe.domain.comment.exception.CommentException;
 import com.project.likelion13thbe.domain.comment.repository.CommentRepository;
 import com.project.likelion13thbe.domain.member.entity.Member;
-import com.project.likelion13thbe.domain.member.exception.MemberErrorCode;
-import com.project.likelion13thbe.domain.member.exception.MemberException;
 import com.project.likelion13thbe.domain.member.repository.MemberRepository;
 import com.project.likelion13thbe.domain.review.entity.Review;
 import com.project.likelion13thbe.domain.review.exception.ReviewErrorCode;
@@ -29,10 +27,7 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     private final ReviewRepository reviewRepository;
 
     @Override
-    public CommentResponseDTO.CommentCreateResponseDTO createComment(Long reviewId, CommentRequestDTO.CommentCreateRequestDTO commentCreateRequestDTO) {
-        Member member = memberRepository.findById(commentCreateRequestDTO.memberId())
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-
+    public CommentResponseDTO.CommentCreateResponseDTO createComment(Long reviewId, CommentRequestDTO.CommentCreateRequestDTO commentCreateRequestDTO, Member member) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
 

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
@@ -51,9 +51,13 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     }
 
     @Override
-    public void deleteComment(Long commentId) {
+    public void deleteComment(Long commentId, Member member) {
         Comment comment = commentRepository.findByIdAndNotDeleted(commentId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getMember().getId().equals(member.getId())) {
+            throw new CommentException(CommentErrorCode.UNAUTHORIZED);
+        }
 
         comment.delete();
     }

--- a/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/comment/service/command/CommentCommandServiceImpl.java
@@ -39,9 +39,13 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     }
 
     @Override
-    public void updateComment(Long commentId, CommentRequestDTO.CommentUpdateRequestDTO commentUpdateRequestDTO) {
+    public void updateComment(Long commentId, CommentRequestDTO.CommentUpdateRequestDTO commentUpdateRequestDTO, Member member) {
         Comment comment = commentRepository.findByIdAndNotDeleted(commentId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getMember().getId().equals(member.getId())) {
+            throw new CommentException(CommentErrorCode.UNAUTHORIZED);
+        }
 
         comment.update(commentUpdateRequestDTO.content());
     }

--- a/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
@@ -124,11 +124,12 @@ public class MemberController {
     }
 
 
-    @DeleteMapping("/{memberId}")
+    @DeleteMapping
     @Operation(summary = "회원 탈퇴")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK")})
-    public CustomResponse<String> deleteMember(@PathVariable Long memberId) {
+    public CustomResponse<String> deleteMember(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMember().getId();
         memberCommandService.deleteMember(memberId);
         return CustomResponse.onSuccess("회원 탈퇴 성공");
     }

--- a/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
@@ -6,7 +6,6 @@ import com.project.likelion13thbe.domain.member.service.command.MemberCommandSer
 import com.project.likelion13thbe.domain.member.service.query.MemberQueryService;
 import com.project.likelion13thbe.domain.review.dto.response.ReviewResponseDTO;
 import com.project.likelion13thbe.domain.review.service.query.ReviewQueryService;
-import com.project.likelion13thbe.domain.review.service.query.ReviewQueryServiceImpl;
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
 import com.project.likelion13thbe.global.security.entity.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
@@ -52,8 +52,9 @@ public class MemberController {
     })
     @PatchMapping("/password-reset/{email}")
     public CustomResponse<String> resetPassword(
-            @PathVariable String email,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody MemberRequestDTO.ResetPasswordRequestDTO resetPasswordRequestDTO) {
+        String email = userDetails.getMember().getEmail();
         memberCommandService.updatePassword(email, resetPasswordRequestDTO);
         return CustomResponse.onSuccess("비밀번호 변경 성공");
     }

--- a/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/controller/MemberController.java
@@ -5,7 +5,10 @@ import com.project.likelion13thbe.domain.member.dto.response.MemberResponseDTO;
 import com.project.likelion13thbe.domain.member.service.command.MemberCommandService;
 import com.project.likelion13thbe.domain.member.service.query.MemberQueryService;
 import com.project.likelion13thbe.domain.review.dto.response.ReviewResponseDTO;
+import com.project.likelion13thbe.domain.review.service.query.ReviewQueryService;
+import com.project.likelion13thbe.domain.review.service.query.ReviewQueryServiceImpl;
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
+import com.project.likelion13thbe.global.security.entity.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -15,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -25,6 +29,7 @@ public class MemberController {
 
     private final MemberCommandService memberCommandService;
     private final MemberQueryService memberQueryService;
+    private final ReviewQueryService reviewQueryService;
 
     @Operation(summary = "일반 로그인")
     @ApiResponses({
@@ -80,8 +85,9 @@ public class MemberController {
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ReviewResponseDTO.ReviewListResponseDTO.class))),})
     @GetMapping("/my/reviews")
-    public ResponseEntity<ReviewResponseDTO.ReviewListResponseDTO> getMyReviews() {
-        return null;
+    public CustomResponse<ReviewResponseDTO.ReviewListResponseDTO> getMyReviews(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMember().getId();
+        return CustomResponse.onSuccess(HttpStatus.OK, reviewQueryService.getReviewsByMemberId(memberId));
     }
 
     @Operation(summary = "카카오 로그인")

--- a/src/main/java/com/project/likelion13thbe/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/converter/MemberConverter.java
@@ -3,10 +3,12 @@ package com.project.likelion13thbe.domain.member.converter;
 import com.project.likelion13thbe.domain.member.dto.request.MemberRequestDTO;
 import com.project.likelion13thbe.domain.member.dto.response.MemberResponseDTO;
 import com.project.likelion13thbe.domain.member.entity.Member;
+import com.project.likelion13thbe.domain.member.entity.Role;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
 
@@ -19,7 +21,8 @@ public class MemberConverter {
         String encodedPassword = passwordEncoder.encode(memberCreateRequestDTO.password());
         return Member.builder()
                 .email(memberCreateRequestDTO.email())
-                .password(memberCreateRequestDTO.password())
+                .password(encodedPassword)
+                .role(Role.ROLE_USER)
                 .name(memberCreateRequestDTO.name())
                 .profileImage(memberCreateRequestDTO.profileImage())
                 .socialType(memberCreateRequestDTO.socialType())

--- a/src/main/java/com/project/likelion13thbe/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/converter/MemberConverter.java
@@ -13,7 +13,10 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberConverter {
 
-    public static Member toMember(MemberRequestDTO.MemberCreateRequestDTO memberCreateRequestDTO) {
+    public static Member toMember(
+            MemberRequestDTO.MemberCreateRequestDTO memberCreateRequestDTO,
+            PasswordEncoder passwordEncoder) {
+        String encodedPassword = passwordEncoder.encode(memberCreateRequestDTO.password());
         return Member.builder()
                 .email(memberCreateRequestDTO.email())
                 .password(memberCreateRequestDTO.password())

--- a/src/main/java/com/project/likelion13thbe/domain/member/entity/Member.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/entity/Member.java
@@ -39,6 +39,9 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
 
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
     @OneToMany(mappedBy = "member")
     private List<Product> products = new ArrayList<>();
 

--- a/src/main/java/com/project/likelion13thbe/domain/member/entity/Role.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/entity/Role.java
@@ -1,0 +1,5 @@
+package com.project.likelion13thbe.domain.member.entity;
+
+public enum Role {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/com/project/likelion13thbe/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/exception/MemberErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "회원을 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "회원을 찾을 수 없습니다."),
+    PASSWORD_UNCHANGED(HttpStatus.CONFLICT, "MEMBER409_1", "새 비밀번호가 기존 비밀번호와 같습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/member/service/command/MemberCommandServiceImpl.java
@@ -10,6 +10,7 @@ import com.project.likelion13thbe.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,11 +23,12 @@ import java.util.List;
 @Transactional
 public class MemberCommandServiceImpl implements MemberCommandService {
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public MemberResponseDTO.MemberCreateResponseDTO createMember(MemberRequestDTO.MemberCreateRequestDTO memberCreateRequestDTO) {
         // DTO -> Member
-        Member member = MemberConverter.toMember(memberCreateRequestDTO);
+        Member member = MemberConverter.toMember(memberCreateRequestDTO, passwordEncoder);
 
         // Member Entity DB에 저장
         memberRepository.save(member);
@@ -40,7 +42,12 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        member.updatePassword(passwordResetRequestDTO.password());
+        if (passwordEncoder.matches(passwordResetRequestDTO.password(), member.getPassword())) {
+            throw new MemberException(MemberErrorCode.PASSWORD_UNCHANGED);
+        }
+
+        String encodedPassword = passwordEncoder.encode(passwordResetRequestDTO.password());
+        member.updatePassword(encodedPassword);
     }
 
     @Override

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -65,8 +65,11 @@ public class ReviewController {
             content = @Content(mediaType = "application/json"))
     })
     @PostMapping("/products/{productId}/reviews")
-    public CustomResponse<ReviewResponseDTO.ReviewCreateResponseDTO> createReview(@PathVariable Long productId, @RequestBody ReviewRequestDTO.ReviewCreateRequestDTO reviewCreateRequestDTO) {
-        return CustomResponse.onSuccess(HttpStatus.CREATED, reviewCommandService.createReview(productId, reviewCreateRequestDTO));
+    public CustomResponse<ReviewResponseDTO.ReviewCreateResponseDTO> createReview(
+            @PathVariable Long productId,
+            @RequestBody ReviewRequestDTO.ReviewCreateRequestDTO reviewCreateRequestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return CustomResponse.onSuccess(HttpStatus.CREATED, reviewCommandService.createReview(productId, reviewCreateRequestDTO, userDetails.getMember()));
     }
 
     @Operation(summary = "리뷰 수정")

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import com.project.likelion13thbe.domain.review.dto.response.ReviewResponseDTO;
 import com.project.likelion13thbe.domain.review.service.command.ReviewCommandService;
 import com.project.likelion13thbe.domain.review.service.query.ReviewQueryService;
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
+import com.project.likelion13thbe.global.security.entity.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -82,8 +84,11 @@ public class ReviewController {
                     content = @Content(mediaType = "application/json"))
     })
     @PatchMapping("/reviews/{reviewId}")
-    public CustomResponse<String> editReview(@PathVariable Long reviewId, @RequestBody ReviewRequestDTO.ReviewUpdateRequestDTO reviewUpdateRequestDTO) {
-        reviewCommandService.updateReview(reviewId, reviewUpdateRequestDTO);
+    public CustomResponse<String> editReview(
+            @PathVariable Long reviewId,
+            @RequestBody ReviewRequestDTO.ReviewUpdateRequestDTO reviewUpdateRequestDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        reviewCommandService.updateReview(reviewId, reviewUpdateRequestDTO, userDetails.getMember());
         return CustomResponse.onSuccess("리뷰 수정 성공");
     }
 

--- a/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/controller/ReviewController.java
@@ -100,8 +100,10 @@ public class ReviewController {
                     content = @Content(mediaType = "application/json"))
     })
     @DeleteMapping("/reviews/{reviewId}")
-    public CustomResponse<String> deleteReview(@PathVariable Long reviewId) {
-        reviewCommandService.deleteReview(reviewId);
+    public CustomResponse<String> deleteReview(
+            @PathVariable Long reviewId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        reviewCommandService.deleteReview(reviewId, userDetails.getMember());
         return CustomResponse.onSuccess("리뷰 삭제 성공");
     }
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/dto/request/ReviewRequestDTO.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/dto/request/ReviewRequestDTO.java
@@ -8,9 +8,7 @@ public class ReviewRequestDTO {
     public record ReviewCreateRequestDTO(
             String content,
             Integer rating,
-            String image,
-
-            Long memberId
+            String image
     ) {
     }
 

--- a/src/main/java/com/project/likelion13thbe/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/exception/ReviewErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ReviewErrorCode implements BaseErrorCode {
 
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "리뷰를 찾을 수 없습니다.");
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "리뷰를 찾을 수 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "REVIEW401_1", "이 리뷰에 대한 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/repository/ReviewRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -19,4 +20,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r FROM Review r WHERE r.id < :id AND r.product.id = :productId AND r.deletedAt IS NULL ORDER BY r.id DESC")
     Slice<Review> findAllByIdLessThanOrderByIdDescAndNotDeleted(
             @Param("productId") Long productId, @Param("id") Long reviewId, Pageable pageable);
+
+    @Query("SELECT r FROM Review r WHERE r.member.id = :memberId AND r.deletedAt IS NULL")
+    List<Review> findAllByMemberIdAndNotDeleted(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
@@ -10,5 +10,5 @@ public interface ReviewCommandService {
 
     void updateReview(Long reviewId, ReviewRequestDTO.ReviewUpdateRequestDTO reviewUpdateRequestDTO, Member member);
 
-    void deleteReview(Long reviewId);
+    void deleteReview(Long reviewId, Member member);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
@@ -8,7 +8,7 @@ public interface ReviewCommandService {
 
     ReviewResponseDTO.ReviewCreateResponseDTO createReview(Long productId, ReviewRequestDTO.ReviewCreateRequestDTO reviewCreateRequestDTO, Member member);
 
-    void updateReview(Long reviewId, ReviewRequestDTO.ReviewUpdateRequestDTO reviewUpdateRequestDTO);
+    void updateReview(Long reviewId, ReviewRequestDTO.ReviewUpdateRequestDTO reviewUpdateRequestDTO, Member member);
 
     void deleteReview(Long reviewId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandService.java
@@ -1,11 +1,12 @@
 package com.project.likelion13thbe.domain.review.service.command;
 
+import com.project.likelion13thbe.domain.member.entity.Member;
 import com.project.likelion13thbe.domain.review.dto.request.ReviewRequestDTO;
 import com.project.likelion13thbe.domain.review.dto.response.ReviewResponseDTO;
 
 public interface ReviewCommandService {
 
-    ReviewResponseDTO.ReviewCreateResponseDTO createReview(Long productId, ReviewRequestDTO.ReviewCreateRequestDTO reviewCreateRequestDTO);
+    ReviewResponseDTO.ReviewCreateResponseDTO createReview(Long productId, ReviewRequestDTO.ReviewCreateRequestDTO reviewCreateRequestDTO, Member member);
 
     void updateReview(Long reviewId, ReviewRequestDTO.ReviewUpdateRequestDTO reviewUpdateRequestDTO);
 

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -1,8 +1,6 @@
 package com.project.likelion13thbe.domain.review.service.command;
 
 import com.project.likelion13thbe.domain.member.entity.Member;
-import com.project.likelion13thbe.domain.member.exception.MemberErrorCode;
-import com.project.likelion13thbe.domain.member.exception.MemberException;
 import com.project.likelion13thbe.domain.member.repository.MemberRepository;
 import com.project.likelion13thbe.domain.product.entity.Product;
 import com.project.likelion13thbe.domain.product.exception.ProductErrorCode;
@@ -29,11 +27,10 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     private final ProductRepository productRepository;
 
     @Override
-    public ReviewResponseDTO.ReviewCreateResponseDTO createReview(Long productId, ReviewRequestDTO.ReviewCreateRequestDTO reviewCreateRequestDTO) {
-
-        // 임시로 추가
-        Member member = memberRepository.findById(reviewCreateRequestDTO.memberId())
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    public ReviewResponseDTO.ReviewCreateResponseDTO createReview(
+            Long productId,
+            ReviewRequestDTO.ReviewCreateRequestDTO reviewCreateRequestDTO,
+            Member member) {
 
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -57,9 +57,13 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     }
 
     @Override
-    public void deleteReview(Long reviewId) {
+    public void deleteReview(Long reviewId, Member member) {
         Review review = reviewRepository.findByIdAndNotDeleted(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
+        if (!review.getMember().getId().equals(member.getId())) {
+            throw new ReviewException(ReviewErrorCode.UNAUTHORIZED);
+        }
 
         review.delete();
     }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/command/ReviewCommandServiceImpl.java
@@ -43,10 +43,14 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     }
 
     @Override
-    public void updateReview(Long reviewId, ReviewRequestDTO.ReviewUpdateRequestDTO reviewUpdateRequestDTO) {
+    public void updateReview(Long reviewId, ReviewRequestDTO.ReviewUpdateRequestDTO reviewUpdateRequestDTO, Member member) {
 
         Review review = reviewRepository.findByIdAndNotDeleted(reviewId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
+        if (!review.getMember().getId().equals(member.getId())) {
+            throw new ReviewException(ReviewErrorCode.UNAUTHORIZED);
+        }
 
         review.update(reviewUpdateRequestDTO.content(), reviewUpdateRequestDTO.rating(), reviewUpdateRequestDTO.image());
 

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryService.java
@@ -9,4 +9,6 @@ public interface ReviewQueryService {
     ReviewResponseDTO.ReviewListResponseDTO getReviews();
 
     ReviewResponseDTO.ReviewCursorResponseDTO getReviewCursor(Long productId, Long cursor, Integer size);
+
+    ReviewResponseDTO.ReviewListResponseDTO getReviewsByMemberId(Long memberId);
 }

--- a/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13thbe/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -48,4 +48,11 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
 
         return ReviewConverter.toReviewCursorResponseDTO(reviews);
     }
+
+    @Override
+    public ReviewResponseDTO.ReviewListResponseDTO getReviewsByMemberId(Long memberId) {
+        List<ReviewResponseDTO.ReviewDetailResponseDTO> reviews = reviewRepository.findAllByMemberIdAndNotDeleted(memberId)
+                .stream().map(ReviewConverter::toReviewDetailResponseDTO).toList();
+        return ReviewResponseDTO.ReviewListResponseDTO.builder().reviewList(reviews).build();
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/global/apiPayload/CustomResponse.java
+++ b/src/main/java/com/project/likelion13thbe/global/apiPayload/CustomResponse.java
@@ -41,4 +41,8 @@ public class CustomResponse<T> {
     public static <T> CustomResponse<T> onFailure(String code, String message) {
         return new CustomResponse<>(false, code, message, null);
     }
+
+    public static <T> CustomResponse<T> onFailure(HttpStatus httpStatus, String code, String message) {
+        return new CustomResponse<>(false, code, message, null);
+    }
 }

--- a/src/main/java/com/project/likelion13thbe/global/config/CorsConfig.java
+++ b/src/main/java/com/project/likelion13thbe/global/config/CorsConfig.java
@@ -1,0 +1,46 @@
+package com.project.likelion13thbe.global.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CorsConfig implements WebMvcConfigurer {
+
+    public static CorsConfigurationSource apiConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // 데이터 교환이 가능한 URL 지정
+        ArrayList<String> allowedOrigins = new ArrayList<>();
+        allowedOrigins.add("http://localhost:8080");
+        allowedOrigins.add("http://localhost:3000");
+
+        // 허용하는 HTTP Method 지정
+        ArrayList<String> allowedHttpMethods = new ArrayList<>();
+        allowedHttpMethods.add("GET");
+        allowedHttpMethods.add("POST");
+        allowedHttpMethods.add("PUT");
+        allowedHttpMethods.add("DELETE");
+
+        configuration.setAllowedOrigins(allowedOrigins);
+        configuration.setAllowedMethods(allowedHttpMethods);
+
+        configuration.setAllowedHeaders(Collections.singletonList("*"));
+        configuration.setAllowedHeaders(List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.CONTENT_TYPE));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+
+}

--- a/src/main/java/com/project/likelion13thbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/likelion13thbe/global/config/SecurityConfig.java
@@ -1,0 +1,95 @@
+package com.project.likelion13thbe.global.config;
+
+import com.project.likelion13thbe.domain.member.repository.MemberRepository;
+import com.project.likelion13thbe.global.security.filter.JwtAuthorizationFilter;
+import com.project.likelion13thbe.global.security.handler.JwtAccessDeniedHandler;
+import com.project.likelion13thbe.global.security.handler.JwtAuthenticationEntryPoint;
+import com.project.likelion13thbe.global.security.filter.CustomLoginFilter;
+import com.project.likelion13thbe.global.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    // 인가에 실패한 경우 실행할 예외 처리 handler
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    // 인증에 실패한 경우 실행할 예외 처리 handler
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
+
+    // AuthenticationManager가 인자로 받을 AuthenticationConfiguration 객체 생성자 주입
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    // AuthenticationManager Bean 등록
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtUtil, memberRepository);
+    }
+
+    // 비밀번호를 해시로 암호화 및 검증하는 BCryptPasswordEncoder
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // 허용할 URL을 배열 형태로 관리
+    private final String[] allowUrl = {
+            "/",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/swagger-resources/**",
+            "/api/v1/members/login",
+            "/api/v1/members/signup"
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        CustomLoginFilter loginFilter = new CustomLoginFilter(
+                authenticationManager(authenticationConfiguration), jwtUtil
+        );
+        loginFilter.setFilterProcessesUrl("/api/v1/members/login");
+
+        http
+                .authorizeHttpRequests(request -> request
+                        // allowUrl은 모두 허용
+                        .requestMatchers(allowUrl).permitAll()
+                        // 이외의 요청에 대해서는 인증 필요
+                        .anyRequest().authenticated())
+                // jwtFilter를 UsernamePasswordAuthenticationFilter 앞에 오도록 설정
+                .addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
+                // form Login 비활성화
+                .formLogin(AbstractHttpConfigurer::disable)
+                // httpBasic 비활성화
+                .httpBasic(HttpBasicConfigurer::disable)
+                // csrf 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+                // 인증 인가에 대한 예외처리
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint));
+
+        // build()를 통해 SecurityFilterChain 형태로 반환
+        return http.build();
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/likelion13thbe/global/config/SecurityConfig.java
@@ -2,10 +2,12 @@ package com.project.likelion13thbe.global.config;
 
 import com.project.likelion13thbe.domain.member.repository.MemberRepository;
 import com.project.likelion13thbe.global.security.filter.JwtAuthorizationFilter;
+import com.project.likelion13thbe.global.security.handler.CustomLogoutHandler;
 import com.project.likelion13thbe.global.security.handler.JwtAccessDeniedHandler;
 import com.project.likelion13thbe.global.security.handler.JwtAuthenticationEntryPoint;
 import com.project.likelion13thbe.global.security.filter.CustomLoginFilter;
 import com.project.likelion13thbe.global.security.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,6 +29,9 @@ public class SecurityConfig {
 
     // 인증에 실패한 경우 실행할 예외 처리 handler
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    // 로그아웃 handler 주입
+    private final CustomLogoutHandler customLogoutHandler;
 
     private final JwtUtil jwtUtil;
     private final MemberRepository memberRepository;
@@ -87,7 +92,13 @@ public class SecurityConfig {
                 // 인증 인가에 대한 예외처리
                 .exceptionHandling(exceptionHandling -> exceptionHandling
                         .accessDeniedHandler(jwtAccessDeniedHandler)
-                        .authenticationEntryPoint(jwtAuthenticationEntryPoint));
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint))
+
+                .logout(logout -> logout
+                        .logoutUrl("/api/v1/members/logout")
+                        .addLogoutHandler(customLogoutHandler)
+                        .logoutSuccessHandler((request, response, authentication) ->
+                                response.setStatus(HttpServletResponse.SC_OK)));
 
         // build()를 통해 SecurityFilterChain 형태로 반환
         return http.build();

--- a/src/main/java/com/project/likelion13thbe/global/security/controller/AuthController.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/controller/AuthController.java
@@ -1,13 +1,17 @@
 package com.project.likelion13thbe.global.security.controller;
 
 import com.project.likelion13thbe.global.apiPayload.CustomResponse;
-import com.project.likelion13thbe.global.security.jwt.JwtDTO;
+import com.project.likelion13thbe.global.security.exception.AuthErrorCode;
 import com.project.likelion13thbe.global.security.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,9 +26,30 @@ public class AuthController {
     // 토큰 재발급 API
     @Operation(method = "POST", summary = "토큰 재발급")
     @PostMapping("/reissue")
-    public CustomResponse<?> reissue(@RequestBody JwtDTO jwtDTO) {
+    public ResponseEntity<CustomResponse<?>> reissue(HttpServletRequest request, HttpServletResponse response) {
+
         log.info("[ Auth Controller ] 토큰을 재발급합니다.");
 
-        return CustomResponse.onSuccess(authService.reissueToken(jwtDTO));
+        String refreshToken = getRefreshTokenFromCookie(request);
+
+        if (refreshToken == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(CustomResponse.onFailure(
+                            AuthErrorCode.REFRESH_TOKEN_NOT_FOUNT.getCode(),
+                            AuthErrorCode.REFRESH_TOKEN_NOT_FOUNT.getMessage()
+                    ));
+        }
+        return ResponseEntity.ok(CustomResponse.onSuccess(authService.reissueToken(refreshToken, response)));
+    }
+
+    private String getRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals("refreshToken")) {
+                return cookie.getValue();
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/project/likelion13thbe/global/security/controller/AuthController.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.project.likelion13thbe.global.security.controller;
+
+import com.project.likelion13thbe.global.apiPayload.CustomResponse;
+import com.project.likelion13thbe.global.security.jwt.JwtDTO;
+import com.project.likelion13thbe.global.security.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    // 토큰 재발급 API
+    @Operation(method = "POST", summary = "토큰 재발급")
+    @PostMapping("/reissue")
+    public CustomResponse<?> reissue(@RequestBody JwtDTO jwtDTO) {
+        log.info("[ Auth Controller ] 토큰을 재발급합니다.");
+
+        return CustomResponse.onSuccess(authService.reissueToken(jwtDTO));
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/dto/SecurityDTO.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/dto/SecurityDTO.java
@@ -1,0 +1,10 @@
+package com.project.likelion13thbe.global.security.dto;
+
+public class SecurityDTO {
+
+    public record LoginRequestDTO(
+            String email,
+            String password
+    ) {
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/entity/CustomUserDetails.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/entity/CustomUserDetails.java
@@ -1,0 +1,66 @@
+package com.project.likelion13thbe.global.security.entity;
+
+import com.project.likelion13thbe.domain.member.entity.Member;
+import com.project.likelion13thbe.domain.member.entity.Role;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    private final String email;
+    private final String password;
+    private final Role role;
+
+    public CustomUserDetails(Member member) {
+        this.member = member;
+        this.email = member.getEmail();
+        this.password = member.getPassword();
+        this.role = member.getRole();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(role.name()));
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/entity/Token.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/entity/Token.java
@@ -1,0 +1,21 @@
+package com.project.likelion13thbe.global.security.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Token {
+
+    @Id
+    private String email;
+
+    private String token;
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/exception/AuthErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/exception/AuthErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode implements BaseErrorCode {
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_1", "토큰이 유효하지 않습니다."),;
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_1", "토큰이 유효하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUNT(HttpStatus.UNAUTHORIZED, "AUTH401_2", "refresh 토큰이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/project/likelion13thbe/global/security/exception/AuthErrorCode.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/exception/AuthErrorCode.java
@@ -1,0 +1,16 @@
+package com.project.likelion13thbe.global.security.exception;
+
+import com.project.likelion13thbe.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_1", "토큰이 유효하지 않습니다."),;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/exception/AuthException.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/exception/AuthException.java
@@ -1,0 +1,10 @@
+package com.project.likelion13thbe.global.security.exception;
+
+import com.project.likelion13thbe.global.apiPayload.exception.CustomException;
+
+public class AuthException extends CustomException {
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/filter/CustomLoginFilter.java
@@ -1,0 +1,128 @@
+package com.project.likelion13thbe.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.likelion13thbe.global.apiPayload.CustomResponse;
+import com.project.likelion13thbe.global.security.entity.CustomUserDetails;
+import com.project.likelion13thbe.global.security.dto.SecurityDTO;
+import com.project.likelion13thbe.global.security.jwt.JwtDTO;
+import com.project.likelion13thbe.global.security.jwt.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public Authentication attemptAuthentication(
+            // 필터나 서비스 계층에서는 @NonNull 사용, @NotNull X
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response) throws AuthenticationException {
+
+        log.info("[ Login Filter ] 로그인 시도 : Custom Login Filter 작동");
+        ObjectMapper mapper = new ObjectMapper();
+        SecurityDTO.LoginRequestDTO requestBody;
+
+        try {
+            requestBody = mapper.readValue(request.getInputStream(), SecurityDTO.LoginRequestDTO.class);
+        } catch (IOException e) {
+            throw new AuthenticationServiceException("[ Login Filter ] Request Body 파싱 과정에서 오류가 발생했습니다.");
+        }
+
+        // Request Body에서 email, password 추출
+        String email = requestBody.email();
+        String password = requestBody.password();
+        log.info("[ Login Filter ] Email ---> {}", email);
+        log.info("[ Login Filter ] Password ---> {}", password);
+
+        // UserNamePasswordToken 생성 (인증용 객체)
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(email, password, null);
+
+        log.info("[ Login Filter ] 인증용 객체 UsernamePasswordAuthenticationToken이 생성되었습니다.");
+        log.info("[ Login Filter ] 인증을 시도합니다.");
+
+        // 토큰 검증
+        return authenticationManager.authenticate(authToken);
+    }
+
+    @Override
+    protected void successfulAuthentication(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain chain,
+            @NonNull Authentication authentication) throws IOException, ServletException {
+
+        log.info("[ Login Filter ] 로그인에 성공했습니다.");
+
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal(); // getPrincipal(): 로그인한 사용자 정보를 꺼내는 메서드
+
+        // Client 에게 줄 Response build
+        JwtDTO jwtDTO = JwtDTO.builder()
+                .accessToken(jwtUtil.createJwtAccessToken(customUserDetails))
+                .refreshToken(jwtUtil.createJwtRefreshToken(customUserDetails))
+                .build();
+
+        // CustomResponse 작성
+        CustomResponse<JwtDTO> customResponse = CustomResponse.onSuccess(jwtDTO);
+
+        ObjectMapper mapper = new ObjectMapper();
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        // Body에 토큰을 담은 Response 쓰기
+        response.getWriter().write(mapper.writeValueAsString(customResponse));
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull AuthenticationException failed) throws IOException, ServletException {
+
+        log.info("[ Login Filter ] 로그인에 실패했습니다");
+
+        String errorCode;
+        String errorMessage;
+
+        if (failed instanceof BadCredentialsException) {
+            errorCode = "LOGIN401";
+            errorMessage = "잘못된 정보입니다.";
+        } else if (failed instanceof LockedException) {
+            errorCode = "LOGIN423";
+            errorMessage = "계정이 잠금 상태입니다.";
+        } else if (failed instanceof DisabledException) {
+            errorCode = "LOGIN403";
+            errorMessage = "계정이 비활성화 되었습니다.";
+        } else if (failed instanceof UsernameNotFoundException) {
+            errorCode = "LOGIN404";
+            errorMessage = "계정을 찾을 수 없습니다.";
+        } else if (failed instanceof AuthenticationServiceException) {
+            errorCode = "LOGIN400";
+            errorMessage = "RequestBody 파싱 중 오류가 발생했습니다.";
+        } else {
+            errorCode = "LOGIN500";
+            errorMessage = "인증에 실패했습니다.";
+        }
+
+        // CustomResponse 생성 (데이터는 null로 설정)
+        CustomResponse<Void> customResponse = CustomResponse.onFailure(HttpStatus.UNAUTHORIZED, errorCode, errorMessage);
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/filter/CustomLoginFilter.java
@@ -8,6 +8,7 @@ import com.project.likelion13thbe.global.security.jwt.JwtDTO;
 import com.project.likelion13thbe.global.security.jwt.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
@@ -73,10 +74,15 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal(); // getPrincipal(): 로그인한 사용자 정보를 꺼내는 메서드
 
+        String accessToken = jwtUtil.createJwtAccessToken(customUserDetails);
+        String refreshToken = jwtUtil.createJwtRefreshToken(customUserDetails);
+
+        Cookie refreshCookie = createCookie("refreshToken", refreshToken);
+        response.addCookie(refreshCookie);
+
         // Client 에게 줄 Response build
         JwtDTO jwtDTO = JwtDTO.builder()
-                .accessToken(jwtUtil.createJwtAccessToken(customUserDetails))
-                .refreshToken(jwtUtil.createJwtRefreshToken(customUserDetails))
+                .accessToken(accessToken)
                 .build();
 
         // CustomResponse 작성
@@ -124,5 +130,15 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 
         // CustomResponse 생성 (데이터는 null로 설정)
         CustomResponse<Void> customResponse = CustomResponse.onFailure(HttpStatus.UNAUTHORIZED, errorCode, errorMessage);
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60);
+        cookie.setPath("/");
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+
+        return cookie;
     }
 }

--- a/src/main/java/com/project/likelion13thbe/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,94 @@
+package com.project.likelion13thbe.global.security.filter;
+
+import com.project.likelion13thbe.domain.member.entity.Member;
+import com.project.likelion13thbe.domain.member.exception.MemberErrorCode;
+import com.project.likelion13thbe.domain.member.exception.MemberException;
+import com.project.likelion13thbe.domain.member.repository.MemberRepository;
+import com.project.likelion13thbe.global.security.entity.CustomUserDetails;
+import com.project.likelion13thbe.global.security.jwt.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter { // OncePerRequestFilter: 같은 HTTP 요청에 대해 필터가 딱 한 번만 실행되도록 보장
+
+    private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+        log.info("[ JwtAuthorizationFilter ] 인가 필터 작동 ");
+
+        try {
+            // Request 에서 access token 추출
+            String accessToken = jwtUtil.resolveAccessToken(request);
+
+            // accessToken이 없다면 다음 필터로 넘어감
+            if (accessToken == null) {
+                log.info("[ JwtAuthorizationFilter ] Access Token이 존재하지 않습니다. 다음 필터로 넘어갑니다.");
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // 토큰 인증
+            authenticateAccessToken(accessToken);
+
+            log.info("[ JwtAuthorizationFilter ] 종료. 다음 필터로 넘어갑니다.");
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            logger.warn("[ JwtAuthorizationFilter ] accessToken이 만료되었습니다.");
+            response.setStatus(HttpStatus.UNAUTHORIZED.value()); // 401 return
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write("Access Token이 만료되었습니다.");
+        }
+    }
+
+    private void authenticateAccessToken(String accessToken) {
+        log.info("[ JwtAuthorizationFilter ] 토큰으로 인가 과정을 시작합니다.");
+
+        // AccessToken 유효성 검증
+        jwtUtil.validateToken(accessToken);
+        log.info("[ JwtAuthorizationFilter ] Access Token 유효성 검증 성공");
+
+        // email 추출
+        String email = jwtUtil.getEmail(accessToken);
+
+        // DB에서 member 조회
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // CustomUserDetail 객체 생성
+        CustomUserDetails userDetails = new CustomUserDetails(member);
+
+        log.info("[ JwtAuthorizationFilter ] UserDetails 객체 생성 성공");
+
+        // Spring Security 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        );
+
+        // SecurityContextHolder에 현재 인증 객체 저장
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        log.info("[ JwtAuthorizationFilter ] 인증 객체 저장 완료");
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/handler/CustomLogoutHandler.java
@@ -1,0 +1,55 @@
+package com.project.likelion13thbe.global.security.handler;
+
+import com.project.likelion13thbe.global.security.jwt.JwtUtil;
+import com.project.likelion13thbe.global.security.repository.TokenRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomLogoutHandler implements LogoutHandler {
+
+    private final JwtUtil jwtUtil;
+    private final TokenRepository tokenRepository;
+
+    @Override
+    @Transactional
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        log.info("[ LogoutHandler ] 로그아웃 요청");
+
+        String refreshToken = getRefreshTokenFromCookie(request);
+
+        if (refreshToken != null) {
+            jwtUtil.validateToken(refreshToken);
+            String email = jwtUtil.getEmail(refreshToken);
+            tokenRepository.deleteByEmail(email);
+        }
+
+        // cookie에서 refresh token 값 0으로 설정
+        Cookie cookie = new Cookie("refreshToken", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        log.info("[ LogoutHandler ] 쿠키 삭제 완료");
+
+    }
+
+    private String getRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals("refreshToken")) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.project.likelion13thbe.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.likelion13thbe.global.apiPayload.CustomResponse;
+import com.project.likelion13thbe.global.apiPayload.code.GeneralErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        CustomResponse<Object> errorResponse = CustomResponse.onFailure(
+                GeneralErrorCode.FORBIDDEN_403.getCode(),
+                GeneralErrorCode.FORBIDDEN_403.getMessage(),
+                null
+        );
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.project.likelion13thbe.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.likelion13thbe.global.apiPayload.CustomResponse;
+import com.project.likelion13thbe.global.apiPayload.code.GeneralErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        CustomResponse<Object> errorResponse = CustomResponse.onFailure(
+                GeneralErrorCode.UNAUTHORIZED_401.getCode(),
+                GeneralErrorCode.UNAUTHORIZED_401.getMessage(),
+                null
+        );
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/jwt/JwtDTO.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/jwt/JwtDTO.java
@@ -1,0 +1,10 @@
+package com.project.likelion13thbe.global.security.jwt;
+
+import lombok.Builder;
+
+@Builder
+public record JwtDTO(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/jwt/JwtUtil.java
@@ -1,0 +1,183 @@
+package com.project.likelion13thbe.global.security.jwt;
+
+import com.project.likelion13thbe.domain.member.entity.Member;
+import com.project.likelion13thbe.domain.member.exception.MemberErrorCode;
+import com.project.likelion13thbe.domain.member.exception.MemberException;
+import com.project.likelion13thbe.domain.member.repository.MemberRepository;
+import com.project.likelion13thbe.global.security.entity.CustomUserDetails;
+import com.project.likelion13thbe.global.security.repository.TokenRepository;
+import com.project.likelion13thbe.global.security.entity.Token;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SecurityException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final Long accessExpMs;
+    private final Long refreshExpMs;
+    private final TokenRepository tokenRepository;
+    private final MemberRepository memberRepository;
+
+    public JwtUtil(
+            @Value("${spring.jwt.secret}") String secret,
+            @Value("${spring.jwt.token.access-expiration-time}") Long access,
+            @Value("${spring.jwt.token.refresh-expiration-time}") Long refresh,
+            TokenRepository tokenRepo,
+            MemberRepository memberRepository) {
+        this.secretKey = new SecretKeySpec(
+                secret.getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS256.key().build().getAlgorithm());
+        this.accessExpMs = access;
+        this.refreshExpMs = refresh;
+        this.tokenRepository = tokenRepo;
+        this.memberRepository = memberRepository;
+    }
+
+    // JWT 토큰을 입력받아 토큰의 Subject로부터 사용자 Email을 추출하는 메서드
+    public String getEmail(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    // JWT 토큰을 입력받아 토큰의 claim에서 사용자 권한을 추출하는 메서드
+    public String getRole(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("role", String.class);
+    }
+
+    // token 발급 메서드
+    public String tokenProvider(CustomUserDetails customUserDetails, Instant expriation) {
+
+        log.info("[ JwtUtil ] 토큰을 새로 생성합니다.");
+
+        // 현재 시간
+        Instant issuedAt = Instant.now();
+
+        // 토큰에 부여할 권한
+        String authorities = customUserDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        return Jwts.builder()
+                .header()
+                .add("type", "JWT")
+                .and()
+                .subject(customUserDetails.getUsername())
+                .claim("role", authorities)
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expriation))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // 새로운 JWT access 토큰 생성
+    public String createJwtAccessToken(CustomUserDetails customUserDetails) {
+        Instant expiration = Instant.now().plusMillis(accessExpMs);
+
+        return tokenProvider(customUserDetails, expiration);
+    }
+
+    // 새로운 JWT refresh 토큰 생성
+    public String createJwtRefreshToken(CustomUserDetails customUserDetails) {
+        Instant expiration = Instant.now().plusMillis(refreshExpMs);
+        String refreshToken = tokenProvider(customUserDetails, expiration);
+
+        // save Refresh Token to DB
+        tokenRepository.save(Token.builder()
+                .email(customUserDetails.getUsername())
+                .token(refreshToken)
+                .build());
+
+        return refreshToken;
+    }
+
+    // 제공된 refresh 토큰 기반 JwtDto 쌍을 다시 발급
+    public JwtDTO reissueToken(String refreshToken) {
+        // 토큰에서 이메일 추출
+        String email = getEmail(refreshToken);
+
+        // DB에서 해당 사용자 조회
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // CustomUserDetails 생성
+        CustomUserDetails userDetails = new CustomUserDetails(member);
+
+        log.info("[ JwtUtil ] 새로운 토큰을 재발급합니다.");
+
+        // 재발급
+        return new JwtDTO(
+                createJwtAccessToken(userDetails),
+                createJwtRefreshToken(userDetails)
+        );
+    }
+
+
+    // HTTP 요청의 'Authorization' 헤더에서 JWT 액세스 토큰 검색
+    public String resolveAccessToken(HttpServletRequest request) {
+        log.info("[ JwtUtil ] 헤더에서 토큰을 추출합니다.");
+
+        String tokenFromHeader = request.getHeader("Authorization");
+
+        if (tokenFromHeader == null || !tokenFromHeader.startsWith("Bearer ")) {
+            log.warn("[ JwtUtil ] Request Header에 토큰이 존재하지 않습니다.");
+            return null;
+        }
+
+        log.info("[ JwtUtil ] 헤더에 토큰이 존재합니다.");
+
+        return tokenFromHeader.split(" ")[1]; // Bearer와 분리하여 토큰 추출
+    }
+
+    public void validateToken(String token) {
+        log.info("[ JwtUtil ] 토큰의 유효성을 검증합니다.");
+
+        try {
+            // 구문 분석 시스템의 시계가 JWT를 생성한 시스템의 시계 오차 고려
+            // 약 3분 허용
+            long seconds = 3 * 60;
+            boolean isExpired = Jwts
+                    .parser()
+                    .clockSkewSeconds(seconds) // 오차 허용
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getExpiration()
+                    .before(new Date());
+
+            if (isExpired) log.info("만료된 JWT 토큰입니다.");
+
+        } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            // 원하는 Exception throw
+            throw new SecurityException("잘못된 토큰입니다.");
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredJwtException(null, null, "만료된 JWT 토큰입니다.");
+        }
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/jwt/JwtUtil.java
@@ -111,6 +111,9 @@ public class JwtUtil {
         // 토큰에서 이메일 추출
         String email = getEmail(refreshToken);
 
+        // 기존 refresh token 삭제
+        tokenRepository.deleteByEmail(email);
+
         // DB에서 해당 사용자 조회
         Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/project/likelion13thbe/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/jwt/JwtUtil.java
@@ -161,7 +161,11 @@ public class JwtUtil {
                     .getExpiration()
                     .before(new Date());
 
-            if (isExpired) log.info("만료된 JWT 토큰입니다.");
+            if (isExpired){
+                log.info("만료된 JWT 토큰입니다.");
+                throw new ExpiredJwtException(null, null, "만료된 JWT 토큰입니다.");
+            }
+
 
         } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
             // 원하는 Exception throw

--- a/src/main/java/com/project/likelion13thbe/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/jwt/JwtUtil.java
@@ -60,16 +60,6 @@ public class JwtUtil {
                 .getSubject();
     }
 
-    // JWT 토큰을 입력받아 토큰의 claim에서 사용자 권한을 추출하는 메서드
-    public String getRole(String token) {
-        return Jwts.parser()
-                .verifyWith(secretKey)
-                .build()
-                .parseSignedClaims(token)
-                .getPayload()
-                .get("role", String.class);
-    }
-
     // token 발급 메서드
     public String tokenProvider(CustomUserDetails customUserDetails, Instant expriation) {
 

--- a/src/main/java/com/project/likelion13thbe/global/security/repository/TokenRepository.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/repository/TokenRepository.java
@@ -1,0 +1,11 @@
+package com.project.likelion13thbe.global.security.repository;
+
+import com.project.likelion13thbe.global.security.entity.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+
+    Optional<Token> findByEmail(String email);
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/repository/TokenRepository.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/repository/TokenRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface TokenRepository extends JpaRepository<Token, Long> {
 
     Optional<Token> findByEmail(String email);
+
+    void deleteByEmail(String email);
 }

--- a/src/main/java/com/project/likelion13thbe/global/security/service/AuthService.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/service/AuthService.java
@@ -6,6 +6,8 @@ import com.project.likelion13thbe.global.security.exception.AuthException;
 import com.project.likelion13thbe.global.security.jwt.JwtDTO;
 import com.project.likelion13thbe.global.security.jwt.JwtUtil;
 import com.project.likelion13thbe.global.security.repository.TokenRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,32 +20,48 @@ public class AuthService {
     private final JwtUtil jwtUtil;
     private final TokenRepository tokenRepository;
 
-    public JwtDTO reissueToken(JwtDTO jwtDTO) {
+    public JwtDTO reissueToken(String refreshToken, HttpServletResponse response) {
         log.info("[ Auth Service ] 토큰 재발급을 시작합니다");
 
-        String accessToken = jwtDTO.accessToken();
-        String refreshToken = jwtDTO.refreshToken();
+        // refresh token 유효성 검사
+        jwtUtil.validateToken(refreshToken);
+
+        log.info("[ Auth Service ] Refresh Token이 유효합니다.");
 
         // Refresh Token으로부터 사용자 email 추출
         String email = jwtUtil.getEmail(refreshToken);
         log.info("[ Auth Service ] Email ---> {}", email);
 
         // DB에 저장된 refresh token 가져오기
-        Token refreshTokenByDB = tokenRepository.findByEmail(email).orElseThrow(
+        Token savedRefreshToken = tokenRepository.findByEmail(email).orElseThrow(
                 () -> new AuthException(AuthErrorCode.INVALID_TOKEN)
         );
 
-        // Refresh Token 유효성 검사
-        jwtUtil.validateToken(refreshToken);
-
-        log.info("[ Auth Service ] Refresh Token이 유효합니다.");
-
-        // DB에서 찾은 refresh token과 요청으로 온 refresh token이 일치하면 새로운 토큰 발급
-        if (refreshTokenByDB.getToken().equals(refreshToken)) {
-            log.info("[ Auth Service ] 토큰을 재발급합니다.");
-            return jwtUtil.reissueToken(refreshToken);
-        } else {
+        // DB에서 찾은 refresh token과 요청으로 온 refresh token이 일치하는지 검사
+        if (!savedRefreshToken.getToken().equals(refreshToken)) {
             throw new AuthException(AuthErrorCode.INVALID_TOKEN);
         }
+
+        // 새 refresh 토큰 재발급
+        JwtDTO jwtDTO = jwtUtil.reissueToken(refreshToken);
+
+        // 새 refresh Token을 쿠키에 담아 응답
+        Cookie refreshCookie = createCookie("refreshToken", jwtDTO.refreshToken());
+        response.addCookie(refreshCookie);
+
+        // 새 access 토큰만 body로 변환
+        return JwtDTO.builder()
+                .accessToken(jwtDTO.accessToken())
+                .build();
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60);
+        cookie.setPath("/");
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+
+        return cookie;
     }
 }

--- a/src/main/java/com/project/likelion13thbe/global/security/service/AuthService.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/service/AuthService.java
@@ -1,0 +1,49 @@
+package com.project.likelion13thbe.global.security.service;
+
+import com.project.likelion13thbe.global.security.entity.Token;
+import com.project.likelion13thbe.global.security.exception.AuthErrorCode;
+import com.project.likelion13thbe.global.security.exception.AuthException;
+import com.project.likelion13thbe.global.security.jwt.JwtDTO;
+import com.project.likelion13thbe.global.security.jwt.JwtUtil;
+import com.project.likelion13thbe.global.security.repository.TokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtUtil jwtUtil;
+    private final TokenRepository tokenRepository;
+
+    public JwtDTO reissueToken(JwtDTO jwtDTO) {
+        log.info("[ Auth Service ] 토큰 재발급을 시작합니다");
+
+        String accessToken = jwtDTO.accessToken();
+        String refreshToken = jwtDTO.refreshToken();
+
+        // Refresh Token으로부터 사용자 email 추출
+        String email = jwtUtil.getEmail(refreshToken);
+        log.info("[ Auth Service ] Email ---> {}", email);
+
+        // DB에 저장된 refresh token 가져오기
+        Token refreshTokenByDB = tokenRepository.findByEmail(email).orElseThrow(
+                () -> new AuthException(AuthErrorCode.INVALID_TOKEN)
+        );
+
+        // Refresh Token 유효성 검사
+        jwtUtil.validateToken(refreshToken);
+
+        log.info("[ Auth Service ] Refresh Token이 유효합니다.");
+
+        // DB에서 찾은 refresh token과 요청으로 온 refresh token이 일치하면 새로운 토큰 발급
+        if (refreshTokenByDB.getToken().equals(refreshToken)) {
+            log.info("[ Auth Service ] 토큰을 재발급합니다.");
+            return jwtUtil.reissueToken(refreshToken);
+        } else {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/project/likelion13thbe/global/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/project/likelion13thbe/global/security/service/CustomUserDetailsService.java
@@ -1,0 +1,44 @@
+package com.project.likelion13thbe.global.security.service;
+
+import com.project.likelion13thbe.domain.member.entity.Member;
+import com.project.likelion13thbe.domain.member.exception.MemberErrorCode;
+import com.project.likelion13thbe.domain.member.exception.MemberException;
+import com.project.likelion13thbe.domain.member.repository.MemberRepository;
+import com.project.likelion13thbe.global.security.entity.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    // username(email)로 CustomUserDetail 가져오기
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        log.info("[ CustomUserDetailsService ] Email을 이용하여 User를 검색합니다.");
+//        Optional<Member> userEntity = memberRepository.findByEmailAndNotDeleted(email);
+//        if (userEntity.isPresent()) {
+//            Member member = userEntity.get();
+//            return new CustomUserDetails(member.getEmail(), member.getPassword(), member.getRole());
+//        }
+//        throw new UsernameNotFoundException("Member Not Found");
+
+
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        log.info("Member Role: {}", member.getRole());
+
+        return new CustomUserDetails(member);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,12 +8,17 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
-    jpa:
-      database: mysql # 사용할 DB 유형 지정 (MySQL)
-      database-platform: org.hibernate.dialect.MySQLDialect # Hibernate에서 사용할 MySQL 방언(dialect) 지정
-      show-sql: true # 실행된 SQL 쿼리를 콘솔에 출력할지 여부
+  jpa:
+    database: mysql # 사용할 DB 유형 지정 (MySQL)
+    database-platform: org.hibernate.dialect.MySQLDialect # Hibernate에서 사용할 MySQL 방언(dialect) 지정
+    show-sql: true # 실행된 SQL 쿼리를 콘솔에 출력할지 여부
+    hibernate:
+       ddl-auto: update # 애플리케이션 실행 시 DB 스키마의 상태 설정
+    properties:
       hibernate:
-        ddl-auto: update # 애플리케이션 실행 시 DB 스키마의 상태 설정
-      properties:
-        hibernate:
-          format_sql: true # 출력되는 SQL 쿼리를 보기 좋게 포맷팅
+        format_sql: true # 출력되는 SQL 쿼리를 보기 좋게 포맷팅
+  jwt:
+    secret: ${SECRET_KEY}
+    token:
+      access-expiration-time: 3600000
+      refresh-expiration-time: 86400000


### PR DESCRIPTION
# ☝️Issue Number

- #69 

##  📌 개요

프로젝트에 시큐리티 적용
- PasswordEncoder
로그인과 비밀번호 변경 시에 사용되는 DTO에 PasswordEncoder를 적용해보았습니다 fee20ceea6865522ffff5a838b3f1fb4f3f9de98
- 시큐리티 추가 로직
- @AuthenticationPricipal
이전에 임시로 memberId를 받아서 처리했던 인가가 필요했던 모든 부분을 `@AuthenticationPricipal`으로 처리했습니다 😎
아래 커밋 내용 참고부탁드립ㄴㅣ다
- 로그아웃 핸들러
로그인처럼 커스텀 필터를 만들어야 하나 고민했다가 그냥 로그아웃 핸들러로 구현했습니다 '!!! f4433100cf61073a1981f4b760f58c73e2161327


## 🔁 변경 사항

## 📸 스크린샷
<img width="477" alt="image" src="https://github.com/user-attachments/assets/555c746f-7167-4c3b-8b34-a98c5aca5467" />

refresh token은 쿠키를 통해 응답하도록 구현했습니다 !!
swagger로 쿠키 보는 방법을 모르는 이슈 .,, 로 postman으로 확인해봤습니다


## 👀 기타 더 이야기해볼 점
- Role은 Enum으로 만들었습니다 ,,, e96a3e49296651c5d5cea2c952eed209db8b2e0e
- CustomUserDetails에서 Member 엔티티 객체를 받아서 썼는데 괜찮을까요 ??
강의자료 따라서 해보려고 했는데 잘 안 돼서 이렇게 해봤습니다.,,!  820e17cbff8ac92404e47e25173a3c57b5059fbe
- access 토큰과 refresh 토큰을 각각 응답 헤더와 쿠키에 나누어 담아 응답해보았습니다 .. 8205183e442afdf4bb91ac55df1067c1db889333
(이게 맞는지는 모르겠지만.,,😅) 